### PR TITLE
Update entities with require movement enabled if state is changed

### DIFF
--- a/custom_components/composite/device_tracker.py
+++ b/custom_components/composite/device_tracker.py
@@ -208,7 +208,8 @@ class CompositeScanner:
                                         'old_state missing gps data', init)
                         return
                     if (distance(gps[0], gps[1], old_lat, old_lon) <=
-                            gps_accuracy + old_acc):
+                            gps_accuracy + old_acc and
+                            old_state.state == new_state.state):
                         _LOGGER.debug(
                             'For {} skipping update from {}: '
                             'not enough movement'


### PR DESCRIPTION
Couldn't really find a good way to update the battery status either if no movement is detected, but I might look into that aswell, though a generic sensor that determines which device was last updated works well for now.