### PR TITLE
Add support for TimezoneFinderL class from timezonefinder

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,13 @@ sudo apt install libatlas3-base
 
 `timezonefinderL==2.0.1`  
 `timezonefinder`  
+`timezonefinder<6`  
 `timezonefinder==4.2.0`
+
+- **tz_finder_class** (*Optional*): Specifies which class to use. Only applies when using `timezonefinder` package. Valid options are `TimezoneFinder` and `TimezoneFinderL`. The default is `TimezoneFinder`.
+
+>Note: Starting with release 4.4.0 the `timezonefinder` package provides two classes to choose from: the original `TimezoneFinder` class, and a new class named `TimezoneFinderL`, which effectively replaces the functionality of the `timezonefinderL` package.
+
 ### `device_tracker` platform
 
 - **entity_id**: Entity IDs of watched device tracker devices. Can be a single entity ID, a list of entity IDs, or a string containing multiple entity IDs separated by commas.
@@ -88,7 +94,8 @@ time_zone | The name of the time zone in which the device is located, or `unknow
 ### Example Full Config
 ```yaml
 composite:
-  tz_finder: timezonefinderL==2.0.1
+  tz_finder: timezonefinder<6
+  tz_finder_class: TimezoneFinderL
 device_tracker:
   - platform: composite
     name: me

--- a/custom_components/composite/__init__.py
+++ b/custom_components/composite/__init__.py
@@ -13,11 +13,18 @@ from .const import CONF_TIME_AS, DOMAIN, TZ_DEVICE_LOCAL, TZ_DEVICE_UTC
 
 CONF_TZ_FINDER = "tz_finder"
 DEFAULT_TZ_FINDER = "timezonefinderL==4.0.2"
+CONF_TZ_FINDER_CLASS = "tz_finder_class"
+TZ_FINDER_CLASS_OPTS = ["TimezoneFinder", "TimezoneFinderL"]
 
 CONFIG_SCHEMA = vol.Schema(
     {
         vol.Optional(DOMAIN, default=dict): vol.Schema(
-            {vol.Optional(CONF_TZ_FINDER, default=DEFAULT_TZ_FINDER): cv.string}
+            {
+                vol.Optional(CONF_TZ_FINDER, default=DEFAULT_TZ_FINDER): cv.string,
+                vol.Optional(
+                    CONF_TZ_FINDER_CLASS, default=TZ_FINDER_CLASS_OPTS[0]
+                ): vol.In(TZ_FINDER_CLASS_OPTS),
+            }
         ),
     },
     extra=vol.ALLOW_EXTRA,
@@ -48,8 +55,16 @@ def setup(hass, config):
 
         if pkg.split("==")[0].strip().endswith("L"):
             from timezonefinderL import TimezoneFinder
-        else:
+
+            tf = TimezoneFinder()
+        elif config[DOMAIN][CONF_TZ_FINDER_CLASS] == "TimezoneFinder":
             from timezonefinder import TimezoneFinder
-        hass.data[DOMAIN] = TimezoneFinder()
+
+            tf = TimezoneFinder()
+        else:
+            from timezonefinder import TimezoneFinderL
+
+            tf = TimezoneFinderL()
+        hass.data[DOMAIN] = tf
 
     return True


### PR DESCRIPTION
Starting with version 4.4.0, the timezonefinder package now includes a TimezoneFinderL class that effectively replaces the timezonefinderL package.