### PR TITLE
Ignore unavailable and unknown states

### DIFF
--- a/custom_components/composite/device_tracker.py
+++ b/custom_components/composite/device_tracker.py
@@ -30,6 +30,7 @@ from homeassistant.const import (
     STATE_HOME,
     STATE_NOT_HOME,
     STATE_ON,
+    STATE_UNAVAILABLE,
     STATE_UNKNOWN,
 )
 import homeassistant.helpers.config_validation as cv
@@ -172,7 +173,7 @@ class CompositeScanner:
         return utc
 
     def _update_info(self, entity_id, old_state, new_state):
-        if new_state is None:
+        if new_state is None or new_state.state in (STATE_UNKNOWN, STATE_UNAVAILABLE):
             return
 
         with self._lock:


### PR DESCRIPTION
Some device trackers (especially the newer entity-based variety, like Life360 just became in 2022.7) and binary sensors can temporarily have unavailable or unknown states. If this was true on two consecutive updates for that entity the composite tracker would stop listening to it.

This change causes the composite tracker to ignore unavailable and unknown states of the input entities, similar to what the Person integration does.