### PR TITLE
Convert to entity-based trackers

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,11 +89,17 @@ NOTE: Once legacy support is removed, this variable, with at least one entry, wi
 
 ### Tracker entries
 
-- **entity_id**: Entity IDs of watched device tracker devices. Can be a single entity ID, a list of entity IDs, or a string containing multiple entity IDs separated by commas. Another option is to specify a dictionary with `entity` specifying the entity ID, and `all_states` specifying a boolean value that controls whether or not to use all states of the entity (rather than just the "Home" state, which is the default.)
+- **entity_id**: Specifies the watched entities. Can be an entity ID, a dictionary (see [Entity Dictionary](#entity-dictionary)), or a list containing any combination of these.
 - **name**: Friendly name of composite device.
 - **id** (*Optional*): Object ID (i.e., part of entity ID after the dot) of composite device. If not supplied, then object ID will be generated from the `name` variable. For example, `My Name` would result in an entity ID of `device_tracker.my_name`.
 - **require_movement** (*Optional*): `true` or `false`. If `true`, will skip update from a GPS-based tracker if it has not moved. Specifically, if circle defined by new GPS coordinates and accuracy overlaps circle defined by previous GPS coordinates and accuracy then update will be ignored.
 - **time_as** (*Optional*): One of `utc`, `local`, `device_or_utc` or `device_or_local`. `utc` shows time attributes in UTC. `local` shows time attributes per HA's `time_zone` configuration. `device_or_utc` and `device_or_local` attempt to determine the time zone in which the device is located based on its GPS coordinates. The name of the time zone (or `unknown`) will be shown in a new attribute named `time_zone`. If the time zone can be determined, then time attributes will be shown in that time zone. If the time zone cannot be determined, then time attributes will be shown in UTC if `device_or_utc` is selected, or in HA's local time zone if `device_or_local` is selected.
+
+#### Entity Dictionary
+
+- **entity**: Entity ID of an entity to watch.
+- **all_states** (*Optional*): `true` or `false`. Default is `false`. If `true`, use all states of the entity. If `false`, only use the "Home" state. NOTE: This option is ignored for entities whose `source_type` is `gps` for which all states are always used.
+- **use_picture** (*Optional*): `true` or `false`. Default is `false`. If `true`, use the entity's picture for the composite. Can only be `true` for at most one of the entities.
 
 ## Watched device notes
 
@@ -139,7 +145,8 @@ composite:
     - name: Me
       time_as: local
       entity_id:
-        - device_tracker.platform1_me
+        - entity: device_tracker.platform1_me
+          use_picture: true
         - device_tracker.platform2_me
         - device_tracker.router_my_device
         - entity: binary_sensor.i_am_home
@@ -147,7 +154,9 @@ composite:
     - name: Better Half
       id: wife
       require_movement: false
-      entity_id: device_tracker.platform_wife
+      entity_id:
+        entity: device_tracker.platform_wife
+        use_picture: true
 ```
 
 ### Time zone examples

--- a/README.md
+++ b/README.md
@@ -8,15 +8,38 @@ Follow the installation instructions below.
 Then add the desired configuration. Here is an example of a typical configuration:
 
 ```yaml
-device_tracker:
-  - platform: composite
-    name: me
-    time_as: device_or_local
-    entity_id:
-      - device_tracker.platform1_me
-      - device_tracker.platform2_me
-      - binary_sensor.i_am_home
+composite:
+  trackers:
+    - name: Me
+      time_as: device_or_local
+      entity_id:
+        - device_tracker.platform1_me
+        - device_tracker.platform2_me
+        - binary_sensor.i_am_home
 ```
+
+## Legacy vs entity-based implementation
+
+When this integration was originally created the
+[Device Tracker](https://www.home-assistant.io/integrations/device_tracker/)
+component worked differently than it does today.
+That older implementation is now referred to as the "legacy" implementation,
+and is the one that creates and uses the `known_devices.yaml` file in HA's configuration folder.
+
+Starting with the 2.4.0 release this integration now uses the newer entity-based implementation.
+That implementation stores configuration and entity settings in HA's `.storage` folder,
+and supports reconfiguring those items via the Integrations and Entities pages in the UI.
+The initial configuration, though, is still done via YAML, and is "imported" and will show up
+on the Integrations UI page as such.
+In the future the integration will likely allow adding & fully reconfiguring composite trackers
+via the UI.
+
+To allow for a smoother transition, the integration currently still supports the older,
+legacy implementation as well. If it sees entries under `device_tracker`, it will still create the
+entities as before, but it will issue a warning and a persistent notification that the configuration
+has changed and suggest how to edit your configuration accordingly.
+
+At some point (i.e., in an upcoming 3.0.0 release) legacy support will be removed.
 
 ## Installation
 ### Manual
@@ -24,6 +47,7 @@ device_tracker:
 Place a copy of:
 
 [`__init__.py`](custom_components/composite/__init__.py) at `<config>/custom_components/composite/__init__.py`  
+[`config_flow.py`](custom_components/composite/config_flow.py) at `<config>/custom_components/composite/config_flow.py`  
 [`const.py`](custom_components/composite/const.py) at `<config>/custom_components/composite/const.py`  
 [`device_tracker.py`](custom_components/composite/device_tracker.py) at `<config>/custom_components/composite/device_tracker.py`  
 [`manifest.json`](custom_components/composite/manifest.json) at `<config>/custom_components/composite/manifest.json`
@@ -33,7 +57,7 @@ where `<config>` is your Home Assistant configuration directory.
 >__NOTE__: Do not download the file by using the link above directly. Rather, click on it, then on the page that comes up use the `Raw` button.
 
 ### With HACS
-You can use [HACS](https://hacs.xyz/) to manage installation and updates by adding this repo as a [custom repository](https://hacs.xyz/docs/faq/custom_repositories/) and then searching for and installing the "Composite" integration.
+You can use [HACS](https://hacs.xyz/) to manage installation and updates by adding this repo as a [custom repository](https://hacs.xyz/docs/faq/custom_repositories/).
 
 ### numpy on Raspberry Pi
 
@@ -44,7 +68,9 @@ sudo apt install libatlas3-base
 >Note: This is the same step that would be required if using a standard HA component that uses numpy (such as the [Trend Binary Sensor](https://www.home-assistant.io/components/binary_sensor.trend/)), and is only required if you use `device_or_utc` or `device_or_local` for `time_as`.
 
 ## Configuration variables
-### `composite` integration
+
+- **trackers** (*Optional*): The list of composite trackers to create. For each entry see [Tracker entries](#tracker-entries).
+NOTE: Once legacy support is removed, this variable, with at least one entry, will become required.
 
 - **tz_finder** (*Optional*): Specifies which `timezonefinder` package, and possibly version, to install. Must be formatted as required by `pip`. Default is `timezonefinderL==4.0.2`. Other common values:  
 
@@ -57,10 +83,11 @@ sudo apt install libatlas3-base
 
 >Note: Starting with release 4.4.0 the `timezonefinder` package provides two classes to choose from: the original `TimezoneFinder` class, and a new class named `TimezoneFinderL`, which effectively replaces the functionality of the `timezonefinderL` package.
 
-### `device_tracker` platform
+### Tracker entries
 
 - **entity_id**: Entity IDs of watched device tracker devices. Can be a single entity ID, a list of entity IDs, or a string containing multiple entity IDs separated by commas. Another option is to specify a dictionary with `entity` specifying the entity ID, and `all_states` specifying a boolean value that controls whether or not to use all states of the entity (rather than just the "Home" state, which is the default.)
-- **name**: Object ID (i.e., part of entity ID after the dot) of composite device. For example, `NAME` would result in an entity ID of `device_tracker.NAME`.
+- **name**: Friendly name of composite device.
+- **id** (*Optional*): Object ID (i.e., part of entity ID after the dot) of composite device. If not supplied, then object ID will be generated from the `name` variable. For example, `My Name` would result in an entity ID of `device_tracker.my_name`.
 - **require_movement** (*Optional*): `true` or `false`. Default is `false`. If `true`, will skip update from a GPS-based tracker if it has not moved. Specifically, if circle defined by new GPS coordinates and accuracy overlaps circle defined by previous GPS coordinates and accuracy then update will be ignored.
 - **time_as** (*Optional*): One of `utc`, `local`, `device_or_utc` or `device_or_local`. Default is `utc` which shows time attributes in UTC. `local` shows time attributes per HA's `time_zone` configuration. `device_or_utc` and `device_or_local` attempt to determine the time zone in which the device is located based on its GPS coordinates. The name of the time zone (or `unknown`) will be shown in a new attribute named `time_zone`. If the time zone can be determined, then time attributes will be shown in that time zone. If the time zone cannot be determined, then time attributes will be shown in UTC if `device_or_utc` is selected, or in HA's local time zone if `device_or_local` is selected.
 
@@ -76,9 +103,9 @@ If a watched device has a `battery` or `battery_level` attribute, that will be u
 
 ## known_devices.yaml
 
-The watched devices, and the composite device, should all have `track` set to `true`.
+NOTE: This only applies to "legacy" tracker devices.
 
-It is recommended to _not_ use the native merge feature of the device tracker component (i.e., do not add the MAC address from network-based trackers to a GPS-based tracker. See more details in the [Device Tracker doc page](https://www.home-assistant.io/components/device_tracker/#using-gps-device-trackers-with-local-network-device-trackers).)
+The watched devices, and the composite device, should all have `track` set to `true`.
 
 ## Attributes
 
@@ -101,17 +128,16 @@ time_zone | The name of the time zone in which the device is located, or `unknow
 composite:
   tz_finder: timezonefinder<6
   tz_finder_class: TimezoneFinderL
-device_tracker:
-  - platform: composite
-    name: me
-    time_as: device_or_local
-    require_movement: true
-    entity_id:
-      - device_tracker.platform1_me
-      - device_tracker.platform2_me
-      - device_tracker.router_my_device
-      - entity: binary_sensor.i_am_home
-        all_states: true
+  trackers:
+    - name: Me
+      time_as: device_or_local
+      require_movement: true
+      entity_id:
+        - device_tracker.platform1_me
+        - device_tracker.platform2_me
+        - device_tracker.router_my_device
+        - entity: binary_sensor.i_am_home
+          all_states: true
 ```
 
 ### Time zone examples

--- a/README.md
+++ b/README.md
@@ -121,9 +121,10 @@ The watched devices, and the composite device, should all have `track` set to `t
 
 Attribute | Description
 -|-
-battery | Battery level (in percent, if available.)
+battery_level | Battery level (in percent, if available.)
 battery_charging | Battery charging status (True/False, if available.)
 entity_id | IDs of entities that have contributed to the state of the composite device.
+entity_picture | Picture to use for composite (if configured and available.)
 gps_accuracy | GPS accuracy radius (in meters, if available.)
 last_entity_id | ID of the last entity to update the composite device.
 last_seen | Date and time when current location information was last updated.

--- a/README.md
+++ b/README.md
@@ -69,6 +69,10 @@ sudo apt install libatlas3-base
 
 ## Configuration variables
 
+- **default_options** (*Optional*): Defines default values for corresponding options under **trackers**.
+  - **require_movement** (*Optional*): Default is `false`.
+  - **time_as** (*Optional*): Default is `utc`.
+
 - **trackers** (*Optional*): The list of composite trackers to create. For each entry see [Tracker entries](#tracker-entries).
 NOTE: Once legacy support is removed, this variable, with at least one entry, will become required.
 
@@ -88,8 +92,8 @@ NOTE: Once legacy support is removed, this variable, with at least one entry, wi
 - **entity_id**: Entity IDs of watched device tracker devices. Can be a single entity ID, a list of entity IDs, or a string containing multiple entity IDs separated by commas. Another option is to specify a dictionary with `entity` specifying the entity ID, and `all_states` specifying a boolean value that controls whether or not to use all states of the entity (rather than just the "Home" state, which is the default.)
 - **name**: Friendly name of composite device.
 - **id** (*Optional*): Object ID (i.e., part of entity ID after the dot) of composite device. If not supplied, then object ID will be generated from the `name` variable. For example, `My Name` would result in an entity ID of `device_tracker.my_name`.
-- **require_movement** (*Optional*): `true` or `false`. Default is `false`. If `true`, will skip update from a GPS-based tracker if it has not moved. Specifically, if circle defined by new GPS coordinates and accuracy overlaps circle defined by previous GPS coordinates and accuracy then update will be ignored.
-- **time_as** (*Optional*): One of `utc`, `local`, `device_or_utc` or `device_or_local`. Default is `utc` which shows time attributes in UTC. `local` shows time attributes per HA's `time_zone` configuration. `device_or_utc` and `device_or_local` attempt to determine the time zone in which the device is located based on its GPS coordinates. The name of the time zone (or `unknown`) will be shown in a new attribute named `time_zone`. If the time zone can be determined, then time attributes will be shown in that time zone. If the time zone cannot be determined, then time attributes will be shown in UTC if `device_or_utc` is selected, or in HA's local time zone if `device_or_local` is selected.
+- **require_movement** (*Optional*): `true` or `false`. If `true`, will skip update from a GPS-based tracker if it has not moved. Specifically, if circle defined by new GPS coordinates and accuracy overlaps circle defined by previous GPS coordinates and accuracy then update will be ignored.
+- **time_as** (*Optional*): One of `utc`, `local`, `device_or_utc` or `device_or_local`. `utc` shows time attributes in UTC. `local` shows time attributes per HA's `time_zone` configuration. `device_or_utc` and `device_or_local` attempt to determine the time zone in which the device is located based on its GPS coordinates. The name of the time zone (or `unknown`) will be shown in a new attribute named `time_zone`. If the time zone can be determined, then time attributes will be shown in that time zone. If the time zone cannot be determined, then time attributes will be shown in UTC if `device_or_utc` is selected, or in HA's local time zone if `device_or_local` is selected.
 
 ## Watched device notes
 
@@ -128,16 +132,22 @@ time_zone | The name of the time zone in which the device is located, or `unknow
 composite:
   tz_finder: timezonefinder<6
   tz_finder_class: TimezoneFinderL
+  default_options:
+    time_as: device_or_local
+    require_movement: true
   trackers:
     - name: Me
-      time_as: device_or_local
-      require_movement: true
+      time_as: local
       entity_id:
         - device_tracker.platform1_me
         - device_tracker.platform2_me
         - device_tracker.router_my_device
         - entity: binary_sensor.i_am_home
           all_states: true
+    - name: Better Half
+      id: wife
+      require_movement: false
+      entity_id: device_tracker.platform_wife
 ```
 
 ### Time zone examples

--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ has changed and suggest how to edit your configuration accordingly.
 At some point (i.e., in an upcoming 3.0.0 release) legacy support will be removed.
 
 ## Installation
+### Versions
+
+This custom integration supports HomeAssistant versions 2021.12 or newer, using Python 3.9 or newer.
+
 ### Manual
 
 Place a copy of:

--- a/custom_components/composite/__init__.py
+++ b/custom_components/composite/__init__.py
@@ -30,6 +30,8 @@ from .const import (
     CONF_OPTS,
     CONF_TIME_AS,
     CONF_TRACKERS,
+    DATA_LEGACY_WARNED,
+    DATA_TF,
     DOMAIN,
     TZ_DEVICE_LOCAL,
     TZ_DEVICE_UTC,
@@ -82,6 +84,8 @@ _LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup(hass, config):
+    hass.data[DOMAIN] = {DATA_LEGACY_WARNED: False}
+
     # Get a list of all the object IDs in known_devices.yaml to see if any were created
     # when this integration was a legacy device tracker, or would otherwise conflict
     # with IDs in our config.
@@ -185,7 +189,7 @@ async def async_setup(hass, config):
             from timezonefinder import TimezoneFinderL
 
             tf = TimezoneFinderL()
-        hass.data[DOMAIN] = tf
+        hass.data[DOMAIN][DATA_TF] = tf
 
     return True
 

--- a/custom_components/composite/__init__.py
+++ b/custom_components/composite/__init__.py
@@ -80,23 +80,27 @@ def _defaults(config: dict) -> dict:
 CONFIG_SCHEMA = vol.Schema(
     {
         vol.Optional(DOMAIN, default=dict): vol.All(
-            {
-                vol.Optional(CONF_TZ_FINDER, default=DEFAULT_TZ_FINDER): cv.string,
-                vol.Optional(
-                    CONF_TZ_FINDER_CLASS, default=TZ_FINDER_CLASS_OPTS[0]
-                ): vol.In(TZ_FINDER_CLASS_OPTS),
-                vol.Optional(CONF_DEFAULT_OPTIONS, default=dict): {
-                    vol.Optional(CONF_TIME_AS, default=DEF_TIME_AS): vol.In(
-                        TIME_AS_OPTS
-                    ),
+            vol.Schema(
+                {
+                    vol.Optional(CONF_TZ_FINDER, default=DEFAULT_TZ_FINDER): cv.string,
                     vol.Optional(
-                        CONF_REQ_MOVEMENT, default=DEF_REQ_MOVEMENT
-                    ): cv.boolean,
-                },
-                vol.Optional(CONF_TRACKERS, default=list): vol.All(
-                    cv.ensure_list, [TRACKER], _tracker_ids
-                ),
-            },
+                        CONF_TZ_FINDER_CLASS, default=TZ_FINDER_CLASS_OPTS[0]
+                    ): vol.In(TZ_FINDER_CLASS_OPTS),
+                    vol.Optional(CONF_DEFAULT_OPTIONS, default=dict): vol.Schema(
+                        {
+                            vol.Optional(CONF_TIME_AS, default=DEF_TIME_AS): vol.In(
+                                TIME_AS_OPTS
+                            ),
+                            vol.Optional(
+                                CONF_REQ_MOVEMENT, default=DEF_REQ_MOVEMENT
+                            ): cv.boolean,
+                        }
+                    ),
+                    vol.Optional(CONF_TRACKERS, default=list): vol.All(
+                        cv.ensure_list, [TRACKER], _tracker_ids
+                    ),
+                }
+            ),
             _defaults,
         )
     },

--- a/custom_components/composite/__init__.py
+++ b/custom_components/composite/__init__.py
@@ -131,7 +131,7 @@ async def async_setup(hass, config):
             )
         else:
 
-            async def create_config(conf):
+            async def create_config(conf, options):
                 """Create new config entry."""
                 result = await hass.config_entries.flow.async_init(
                     DOMAIN, context={"source": SOURCE_IMPORT}, data=conf
@@ -142,7 +142,7 @@ async def async_setup(hass, config):
                     result["result"], options=options
                 )
 
-            hass.async_create_task(create_config(conf))
+            hass.async_create_task(create_config(conf, options))
 
     if conflict_ids:
         _LOGGER.warning("%s in %s: skipping", ", ".join(conflict_ids), YAML_DEVICES)
@@ -201,7 +201,7 @@ async def async_setup_entry(hass, entry):
         await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     # async_setup_platforms was new in 2021.5
     elif hasattr(hass.config_entries, "async_setup_platforms"):
-        await hass.config_entries.async_setup_platforms(entry, PLATFORMS)
+        hass.config_entries.async_setup_platforms(entry, PLATFORMS)
     else:
         for platform in PLATFORMS:
             hass.async_create_task(

--- a/custom_components/composite/__init__.py
+++ b/custom_components/composite/__init__.py
@@ -149,7 +149,9 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         if id in legacy_ids:
             conflict_ids.append(id)
         elif id in cfg_entries:
-            hass.config_entries.async_update_entry(cfg_entries[id], **split_conf(conf))
+            hass.config_entries.async_update_entry(
+                cfg_entries[id], **split_conf(conf)  # type: ignore[arg-type]
+            )
         else:
             hass.async_create_task(
                 hass.config_entries.flow.async_init(

--- a/custom_components/composite/__init__.py
+++ b/custom_components/composite/__init__.py
@@ -1,5 +1,8 @@
 """Composite Device Tracker."""
+from __future__ import annotations
+
 import logging
+from typing import Any, cast
 
 import voluptuous as vol
 
@@ -11,9 +14,12 @@ from homeassistant.components.device_tracker.legacy import YAML_DEVICES
 from homeassistant.components.persistent_notification import (
     async_create as pn_async_create,
 )
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_ID, CONF_NAME, CONF_PLATFORM, Platform
+from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.typing import ConfigType
 from homeassistant.util import slugify
 
 from .const import (
@@ -24,8 +30,8 @@ from .const import (
     DOMAIN,
     TZ_DEVICE_LOCAL,
     TZ_DEVICE_UTC,
-    split_conf,
 )
+from .config_flow import split_conf
 from .device_tracker import COMPOSITE_TRACKER
 
 CONF_TZ_FINDER = "tz_finder"
@@ -37,18 +43,20 @@ TRACKER = COMPOSITE_TRACKER.copy()
 TRACKER.update({vol.Required(CONF_NAME): cv.string, vol.Optional(CONF_ID): cv.slugify})
 
 
-def _tracker_ids(value):
+def _tracker_ids(
+    value: list[dict[vol.Required | vol.Optional, Any]]
+) -> list[dict[vol.Required | vol.Optional, Any]]:
     """Determine tracker ID."""
-    ids = []
+    ids: list[str] = []
     for conf in value:
         if CONF_ID not in conf:
-            name = conf[CONF_NAME]
+            name: str = conf[CONF_NAME]
             if name == slugify(name):
                 conf[CONF_ID] = name
                 conf[CONF_NAME] = name.replace("_", " ").title()
             else:
                 conf[CONF_ID] = cv.slugify(conf[CONF_NAME])
-        ids.append(conf[CONF_ID])
+        ids.append(cast(str, conf[CONF_ID]))
     if len(ids) != len(set(ids)):
         raise vol.Invalid("id's must be unique")
     return value
@@ -74,14 +82,15 @@ CONFIG_SCHEMA = vol.Schema(
 _LOGGER = logging.getLogger(__name__)
 
 
-async def async_setup(hass, config):
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
+    """Setup composite integration."""
     hass.data[DOMAIN] = {DATA_LEGACY_WARNED: False}
 
     # Get a list of all the object IDs in known_devices.yaml to see if any were created
     # when this integration was a legacy device tracker, or would otherwise conflict
     # with IDs in our config.
     try:
-        legacy_devices = await hass.async_add_executor_job(
+        legacy_devices: dict[str, dict] = await hass.async_add_executor_job(
             load_yaml_config_file, hass.config.path(YAML_DEVICES)
         )
     except (HomeAssistantError, FileNotFoundError):
@@ -97,27 +106,26 @@ async def async_setup(hass, config):
 
     # Get all existing composite config entries.
     cfg_entries = {
-        entry.data[CONF_ID]: entry
+        cast(str, entry.data[CONF_ID]): entry
         for entry in hass.config_entries.async_entries(DOMAIN)
     }
 
     # For each tracker config, see if it conflicts with a known_devices.yaml entry.
     # If not, update the config entry if one already exists for it in case the config
     # has changed, or create a new config entry if one did not already exist.
-    tracker_configs = config[DOMAIN][CONF_TRACKERS]
-    conflict_ids = []
+    tracker_configs: list[dict[str, Any]] = config[DOMAIN][CONF_TRACKERS]
+    conflict_ids: list[str] = []
     for conf in tracker_configs:
-        id = conf[CONF_ID]
-        kwargs = split_conf(conf)
+        id: str = conf[CONF_ID]
 
         if id in legacy_ids:
             conflict_ids.append(id)
         elif id in cfg_entries:
-            hass.config_entries.async_update_entry(cfg_entries[id], **kwargs)
+            hass.config_entries.async_update_entry(cfg_entries[id], **split_conf(conf))
         else:
             hass.async_create_task(
                 hass.config_entries.flow.async_init(
-                    DOMAIN, context={"source": SOURCE_IMPORT}, **kwargs
+                    DOMAIN, context={"source": SOURCE_IMPORT}, data=conf
                 )
             )
 
@@ -139,13 +147,15 @@ async def async_setup(hass, config):
         )
 
     legacy_configs = [
-        conf for conf in (config.get(DT_DOMAIN) or []) if conf[CONF_PLATFORM] == DOMAIN
+        conf
+        for conf in cast(list[dict[str, Any]], config.get(DT_DOMAIN) or [])
+        if conf[CONF_PLATFORM] == DOMAIN
     ]
     if any(
         conf[CONF_TIME_AS] in (TZ_DEVICE_UTC, TZ_DEVICE_LOCAL)
         for conf in tracker_configs + legacy_configs
     ):
-        pkg = config[DOMAIN][CONF_TZ_FINDER]
+        pkg: str = config[DOMAIN][CONF_TZ_FINDER]
         try:
             await async_process_requirements(hass, f"{DOMAIN}.{DT_DOMAIN}", [pkg])
         except RequirementsNotFound:
@@ -171,7 +181,7 @@ async def async_setup(hass, config):
     return True
 
 
-async def async_setup_entry(hass, entry):
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up config entry."""
     # async_forward_entry_setups was new in 2022.8
     try:
@@ -181,6 +191,6 @@ async def async_setup_entry(hass, entry):
     return True
 
 
-async def async_unload_entry(hass, entry):
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
     return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/custom_components/composite/__init__.py
+++ b/custom_components/composite/__init__.py
@@ -4,17 +4,62 @@ import logging
 
 import voluptuous as vol
 
+from homeassistant.config import load_yaml_config_file
+from homeassistant.config_entries import SOURCE_IMPORT
 from homeassistant.requirements import async_process_requirements, RequirementsNotFound
 from homeassistant.components.device_tracker import DOMAIN as DT_DOMAIN
-from homeassistant.const import CONF_PLATFORM
-import homeassistant.helpers.config_validation as cv
+from homeassistant.components.device_tracker.legacy import YAML_DEVICES
+from homeassistant.components.persistent_notification import (
+    async_create as pn_async_create,
+)
+from homeassistant.const import CONF_ID, CONF_NAME, CONF_PLATFORM
 
-from .const import CONF_TIME_AS, DOMAIN, TZ_DEVICE_LOCAL, TZ_DEVICE_UTC
+# Platform class did not exist before 2021.12
+try:
+    from homeassistant.const import Platform
+
+    PLATFORMS = [Platform.DEVICE_TRACKER]
+except ImportError:
+    PLATFORMS = [DT_DOMAIN]
+
+from homeassistant.exceptions import HomeAssistantError
+import homeassistant.helpers.config_validation as cv
+from homeassistant.util import slugify
+
+from .const import (
+    CONF_OPTS,
+    CONF_TIME_AS,
+    CONF_TRACKERS,
+    DOMAIN,
+    TZ_DEVICE_LOCAL,
+    TZ_DEVICE_UTC,
+)
+from .device_tracker import COMPOSITE_TRACKER
 
 CONF_TZ_FINDER = "tz_finder"
 DEFAULT_TZ_FINDER = "timezonefinderL==4.0.2"
 CONF_TZ_FINDER_CLASS = "tz_finder_class"
 TZ_FINDER_CLASS_OPTS = ["TimezoneFinder", "TimezoneFinderL"]
+TRACKER = COMPOSITE_TRACKER.copy()
+TRACKER.update({vol.Required(CONF_NAME): cv.string, vol.Optional(CONF_ID): cv.slugify})
+
+
+def _tracker_ids(value):
+    """Determine tracker ID."""
+    ids = []
+    for conf in value:
+        if CONF_ID not in conf:
+            name = conf[CONF_NAME]
+            if name == slugify(name):
+                conf[CONF_ID] = name
+                conf[CONF_NAME] = name.replace("_", " ").title()
+            else:
+                conf[CONF_ID] = cv.slugify(conf[CONF_NAME])
+        ids.append(conf[CONF_ID])
+    if len(ids) != len(set(ids)):
+        raise vol.Invalid("id's must be unique")
+    return value
+
 
 CONFIG_SCHEMA = vol.Schema(
     {
@@ -24,8 +69,11 @@ CONFIG_SCHEMA = vol.Schema(
                 vol.Optional(
                     CONF_TZ_FINDER_CLASS, default=TZ_FINDER_CLASS_OPTS[0]
                 ): vol.In(TZ_FINDER_CLASS_OPTS),
+                vol.Optional(CONF_TRACKERS, default=list): vol.All(
+                    cv.ensure_list, [TRACKER], _tracker_ids
+                ),
             }
-        ),
+        )
     },
     extra=vol.ALLOW_EXTRA,
 )
@@ -33,20 +81,92 @@ CONFIG_SCHEMA = vol.Schema(
 _LOGGER = logging.getLogger(__name__)
 
 
-def setup(hass, config):
+async def async_setup(hass, config):
+    # Get a list of all the object IDs in known_devices.yaml to see if any were created
+    # when this integration was a legacy device tracker, or would otherwise conflict
+    # with IDs in our config.
+    try:
+        legacy_devices = await hass.async_add_executor_job(
+            load_yaml_config_file, hass.config.path(YAML_DEVICES)
+        )
+    except (HomeAssistantError, FileNotFoundError):
+        legacy_devices = {}
+    try:
+        legacy_ids = [
+            cv.slugify(id)
+            for id, dev in legacy_devices.items()
+            if cv.boolean(dev.get("track", False))
+        ]
+    except vol.Invalid:
+        legacy_ids = []
+
+    # Get all existing composite config entries.
+    cfg_entries = {
+        entry.data[CONF_ID]: entry
+        for entry in hass.config_entries.async_entries(DOMAIN)
+    }
+
+    # For each tracker config, see if it conflicts with a known_devices.yaml entry.
+    # If not, update the config entry if one already exists for it in case the config
+    # has changed, or create a new config entry if one did not already exist.
+    tracker_configs = config[DOMAIN][CONF_TRACKERS]
+    conflict_ids = []
+    for conf in tracker_configs:
+        # These go in the "static" data field.
+        id = conf[CONF_ID]
+        name = conf[CONF_NAME]
+        # These go in the options field, which can be updated via the UI (once support
+        # for that is added.)
+        options = {k: v for k, v in conf.items() if k in CONF_OPTS}
+
+        if id in legacy_ids:
+            conflict_ids.append(id)
+        elif id in cfg_entries:
+            hass.config_entries.async_update_entry(
+                cfg_entries[id], data={CONF_NAME: name, CONF_ID: id}, options=options
+            )
+        else:
+
+            async def create_config(conf):
+                """Create new config entry."""
+                result = await hass.config_entries.flow.async_init(
+                    DOMAIN, context={"source": SOURCE_IMPORT}, data=conf
+                )
+                # Versions prior to 2021.6 did not support creating with options, so
+                # update the created config entry with the options.
+                hass.config_entries.async_update_entry(
+                    result["result"], options=options
+                )
+
+            hass.async_create_task(create_config(conf))
+
+    if conflict_ids:
+        _LOGGER.warning("%s in %s: skipping", ", ".join(conflict_ids), YAML_DEVICES)
+        if len(conflict_ids) == 1:
+            msg1 = "ID was"
+            msg2 = "conflicts"
+        else:
+            msg1 = "IDs were"
+            msg2 = "conflict"
+        pn_async_create(
+            hass,
+            title="Conflicting IDs",
+            message=f"The following {msg1} found in {YAML_DEVICES}"
+            f" which {msg2} with the configuration of the {DOMAIN} integration."
+            " Please remove from one or the other."
+            f"\n\n{', '.join(conflict_ids)}",
+        )
+
+    legacy_configs = [
+        conf for conf in (config.get(DT_DOMAIN) or []) if conf[CONF_PLATFORM] == DOMAIN
+    ]
     if any(
         conf[CONF_TIME_AS] in (TZ_DEVICE_UTC, TZ_DEVICE_LOCAL)
-        for conf in (config.get(DT_DOMAIN) or [])
-        if conf[CONF_PLATFORM] == DOMAIN
+        for conf in tracker_configs + legacy_configs
     ):
         pkg = config[DOMAIN][CONF_TZ_FINDER]
         try:
-            asyncio.run_coroutine_threadsafe(
-                async_process_requirements(
-                    hass, "{}.{}".format(DOMAIN, DT_DOMAIN), [pkg]
-                ),
-                hass.loop,
-            ).result()
+            await async_process_requirements(hass, f"{DOMAIN}.{DT_DOMAIN}", [pkg])
         except RequirementsNotFound:
             _LOGGER.debug("Process requirements failed: %s", pkg)
             return False
@@ -68,3 +188,35 @@ def setup(hass, config):
         hass.data[DOMAIN] = tf
 
     return True
+
+
+async def async_setup_entry(hass, entry):
+    """Set up config entry."""
+    # async_forward_entry_setups was new in 2022.8
+    if hasattr(hass.config_entries, "async_forward_entry_setups"):
+        await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    # async_setup_platforms was new in 2021.5
+    elif hasattr(hass.config_entries, "async_setup_platforms"):
+        await hass.config_entries.async_setup_platforms(entry, PLATFORMS)
+    else:
+        for platform in PLATFORMS:
+            hass.async_create_task(
+                hass.config_entries.async_forward_entry_setup(entry, platform)
+            )
+    return True
+
+
+async def async_unload_entry(hass, entry):
+    """Unload a config entry."""
+    # async_unload_platforms was new in 2021.5
+    if hasattr(hass.config_entries, "async_unload_platforms"):
+        return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    else:
+        return all(
+            await asyncio.gather(
+                *(
+                    hass.config_entries.async_forward_entry_unload(entry, platform)
+                    for platform in PLATFORMS
+                )
+            )
+        )

--- a/custom_components/composite/config_flow.py
+++ b/custom_components/composite/config_flow.py
@@ -32,5 +32,6 @@ class CompositeConfigFlow(ConfigFlow, domain=DOMAIN):
         self._abort_if_unique_id_configured()
 
         return self.async_create_entry(
-            title=f"{data[CONF_NAME]} (from configuration)", **split_conf(data)
+            title=f"{data[CONF_NAME]} (from configuration)",
+            **split_conf(data),  # type: ignore[arg-type]
         )

--- a/custom_components/composite/config_flow.py
+++ b/custom_components/composite/config_flow.py
@@ -1,0 +1,26 @@
+"""Config flow for Composite integration."""
+from homeassistant.config_entries import ConfigFlow
+from homeassistant.const import CONF_ID, CONF_NAME
+
+from .const import DOMAIN
+
+
+class CompositeConfigFlow(ConfigFlow, domain=DOMAIN):
+    """Composite config flow."""
+
+    VERSION = 1
+
+    async def async_step_import(self, data):
+        """Import config entry from configuration."""
+        name = data[CONF_NAME]
+        id = data[CONF_ID]
+
+        await self.async_set_unique_id(id)
+        self._abort_if_unique_id_configured()
+
+        # Versions prior to 2021.6 did not support creating with options, so only save
+        # main (name/ID) data here. async_setup in __init__.py will update the entry
+        # with the options.
+        return self.async_create_entry(
+            title=f"{name} (from configuration)", data={CONF_NAME: name, CONF_ID: id}
+        )

--- a/custom_components/composite/config_flow.py
+++ b/custom_components/composite/config_flow.py
@@ -2,7 +2,7 @@
 from homeassistant.config_entries import ConfigFlow
 from homeassistant.const import CONF_ID, CONF_NAME
 
-from .const import DOMAIN
+from .const import DOMAIN, split_conf
 
 
 class CompositeConfigFlow(ConfigFlow, domain=DOMAIN):
@@ -12,15 +12,9 @@ class CompositeConfigFlow(ConfigFlow, domain=DOMAIN):
 
     async def async_step_import(self, data):
         """Import config entry from configuration."""
-        name = data[CONF_NAME]
-        id = data[CONF_ID]
-
-        await self.async_set_unique_id(id)
+        await self.async_set_unique_id(data[CONF_ID])
         self._abort_if_unique_id_configured()
 
-        # Versions prior to 2021.6 did not support creating with options, so only save
-        # main (name/ID) data here. async_setup in __init__.py will update the entry
-        # with the options.
         return self.async_create_entry(
-            title=f"{name} (from configuration)", data={CONF_NAME: name, CONF_ID: id}
+            title=f"{data[CONF_NAME]} (from configuration)", **split_conf(data)
         )

--- a/custom_components/composite/config_flow.py
+++ b/custom_components/composite/config_flow.py
@@ -1,8 +1,24 @@
 """Config flow for Composite integration."""
-from homeassistant.config_entries import ConfigFlow
-from homeassistant.const import CONF_ID, CONF_NAME
+from __future__ import annotations
 
-from .const import DOMAIN, split_conf
+from typing import Any
+
+from homeassistant.config_entries import ConfigFlow
+from homeassistant.data_entry_flow import FlowResult
+from homeassistant.const import CONF_ENTITY_ID, CONF_ID, CONF_NAME
+
+from .const import CONF_REQ_MOVEMENT, CONF_TIME_AS, DOMAIN
+
+
+def split_conf(conf: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    """Return pieces of configuration data."""
+    return {
+        kw: {k: v for k, v in conf.items() if k in ks}
+        for kw, ks in (
+            ("data", (CONF_NAME, CONF_ID)),
+            ("options", (CONF_ENTITY_ID, CONF_REQ_MOVEMENT, CONF_TIME_AS)),
+        )
+    }
 
 
 class CompositeConfigFlow(ConfigFlow, domain=DOMAIN):
@@ -10,7 +26,7 @@ class CompositeConfigFlow(ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
-    async def async_step_import(self, data):
+    async def async_step_import(self, data: dict[str, Any]) -> FlowResult:
         """Import config entry from configuration."""
         await self.async_set_unique_id(data[CONF_ID])
         self._abort_if_unique_id_configured()

--- a/custom_components/composite/const.py
+++ b/custom_components/composite/const.py
@@ -1,6 +1,4 @@
 """Constants for Composite Integration."""
-from homeassistant.const import CONF_ENTITY_ID, CONF_ID, CONF_NAME
-
 DOMAIN = "composite"
 
 DATA_LEGACY_WARNED = "legacy_warned"
@@ -18,14 +16,3 @@ TZ_DEVICE_UTC = "device_or_utc"
 TZ_DEVICE_LOCAL = "device_or_local"
 # First item in list is default.
 TIME_AS_OPTS = [TZ_UTC, TZ_LOCAL, TZ_DEVICE_UTC, TZ_DEVICE_LOCAL]
-
-
-def split_conf(conf):
-    """Return pieces of configuration data."""
-    return {
-        kw: {k: v for k, v in conf.items() if k in ks}
-        for kw, ks in (
-            ("data", (CONF_NAME, CONF_ID)),
-            ("options", (CONF_ENTITY_ID, CONF_REQ_MOVEMENT, CONF_TIME_AS)),
-        )
-    }

--- a/custom_components/composite/const.py
+++ b/custom_components/composite/const.py
@@ -1,5 +1,5 @@
 """Constants for Composite Integration."""
-from homeassistant.const import CONF_ENTITY_ID
+from homeassistant.const import CONF_ENTITY_ID, CONF_ID, CONF_NAME
 
 DOMAIN = "composite"
 
@@ -19,4 +19,13 @@ TZ_DEVICE_LOCAL = "device_or_local"
 # First item in list is default.
 TIME_AS_OPTS = [TZ_UTC, TZ_LOCAL, TZ_DEVICE_UTC, TZ_DEVICE_LOCAL]
 
-CONF_OPTS = (CONF_ENTITY_ID, CONF_REQ_MOVEMENT, CONF_TIME_AS)
+
+def split_conf(conf):
+    """Return pieces of configuration data."""
+    return {
+        kw: {k: v for k, v in conf.items() if k in ks}
+        for kw, ks in (
+            ("data", (CONF_NAME, CONF_ID)),
+            ("options", (CONF_ENTITY_ID, CONF_REQ_MOVEMENT, CONF_TIME_AS)),
+        )
+    }

--- a/custom_components/composite/const.py
+++ b/custom_components/composite/const.py
@@ -1,10 +1,13 @@
 """Constants for Composite Integration."""
+from homeassistant.const import CONF_ENTITY_ID
+
 DOMAIN = "composite"
 
 CONF_ALL_STATES = "all_states"
 CONF_ENTITY = "entity"
 CONF_REQ_MOVEMENT = "require_movement"
 CONF_TIME_AS = "time_as"
+CONF_TRACKERS = "trackers"
 
 TZ_UTC = "utc"
 TZ_LOCAL = "local"
@@ -12,3 +15,5 @@ TZ_DEVICE_UTC = "device_or_utc"
 TZ_DEVICE_LOCAL = "device_or_local"
 # First item in list is default.
 TIME_AS_OPTS = [TZ_UTC, TZ_LOCAL, TZ_DEVICE_UTC, TZ_DEVICE_LOCAL]
+
+CONF_OPTS = (CONF_ENTITY_ID, CONF_REQ_MOVEMENT, CONF_TIME_AS)

--- a/custom_components/composite/const.py
+++ b/custom_components/composite/const.py
@@ -3,6 +3,9 @@ from homeassistant.const import CONF_ENTITY_ID
 
 DOMAIN = "composite"
 
+DATA_LEGACY_WARNED = "legacy_warned"
+DATA_TF = "tf"
+
 CONF_ALL_STATES = "all_states"
 CONF_ENTITY = "entity"
 CONF_REQ_MOVEMENT = "require_movement"

--- a/custom_components/composite/const.py
+++ b/custom_components/composite/const.py
@@ -10,6 +10,7 @@ CONF_ENTITY = "entity"
 CONF_REQ_MOVEMENT = "require_movement"
 CONF_TIME_AS = "time_as"
 CONF_TRACKERS = "trackers"
+CONF_USE_PICTURE = "use_picture"
 
 TZ_UTC = "utc"
 TZ_LOCAL = "local"

--- a/custom_components/composite/const.py
+++ b/custom_components/composite/const.py
@@ -5,6 +5,7 @@ DATA_LEGACY_WARNED = "legacy_warned"
 DATA_TF = "tf"
 
 CONF_ALL_STATES = "all_states"
+CONF_DEFAULT_OPTIONS = "default_options"
 CONF_ENTITY = "entity"
 CONF_REQ_MOVEMENT = "require_movement"
 CONF_TIME_AS = "time_as"
@@ -16,3 +17,6 @@ TZ_DEVICE_UTC = "device_or_utc"
 TZ_DEVICE_LOCAL = "device_or_local"
 # First item in list is default.
 TIME_AS_OPTS = [TZ_UTC, TZ_LOCAL, TZ_DEVICE_UTC, TZ_DEVICE_LOCAL]
+
+DEF_TIME_AS = TIME_AS_OPTS[0]
+DEF_REQ_MOVEMENT = False

--- a/custom_components/composite/device_tracker.py
+++ b/custom_components/composite/device_tracker.py
@@ -36,11 +36,11 @@ except ImportError:
         SOURCE_TYPE_ROUTER,
     )
 
-    source_type_type = str
-    source_type_bluetooth = SOURCE_TYPE_BLUETOOTH
-    source_type_bluetooth_le = SOURCE_TYPE_BLUETOOTH_LE
-    source_type_gps = SOURCE_TYPE_GPS
-    source_type_router = SOURCE_TYPE_ROUTER
+    source_type_type = str  # type: ignore[assignment, misc]
+    source_type_bluetooth = SOURCE_TYPE_BLUETOOTH  # type: ignore[assignment]
+    source_type_bluetooth_le = SOURCE_TYPE_BLUETOOTH_LE  # type: ignore[assignment]
+    source_type_gps = SOURCE_TYPE_GPS  # type: ignore[assignment]
+    source_type_router = SOURCE_TYPE_ROUTER  # type: ignore[assignment]
 
 from homeassistant.components.device_tracker.config_entry import TrackerEntity
 from homeassistant.components.persistent_notification import (
@@ -549,8 +549,8 @@ class CompositeScanner:
             else:
                 try:
                     last_seen = dt_util.utc_from_timestamp(
-                        float(last_seen)
-                    )  # type: ignore[arg-type]
+                        float(last_seen)  # type: ignore[arg-type]
+                    )
                 except (TypeError, ValueError):
                     last_seen = new_state.last_updated
 
@@ -627,7 +627,7 @@ class CompositeScanner:
                     else:
                         state = STATE_NOT_HOME
 
-                self._good_entity(entity_id, last_seen, cast(str, source_type), state)
+                self._good_entity(entity_id, last_seen, source_type, state)
 
                 if not self._use_non_gps_data(entity_id, state):
                     return

--- a/custom_components/composite/device_tracker.py
+++ b/custom_components/composite/device_tracker.py
@@ -229,16 +229,6 @@ class CompositeDeviceTracker(TrackerEntity):
         return self._attr_name
 
     @property
-    def device_state_attributes(self):
-        """Return entity specific state attributes."""
-        return self._attr_extra_state_attributes
-
-    @property
-    def extra_state_attributes(self):
-        """Return entity specific state attributes."""
-        return self._attr_extra_state_attributes
-
-    @property
     def force_update(self):
         """Return True if state updates should be forced."""
         return False

--- a/custom_components/composite/device_tracker.py
+++ b/custom_components/composite/device_tracker.py
@@ -381,7 +381,7 @@ class CompositeDeviceTracker(TrackerEntity, RestoreEntity):
         gps_accuracy: int | None = None,
         battery: int | None = None,
         attributes: dict | None = None,
-        source_type: str | None = SOURCE_TYPE_GPS,
+        source_type: str | None = source_type_gps,
         picture: str | None | UndefinedType = UNDEFINED,
     ) -> None:
         """Process update from CompositeScanner."""
@@ -409,7 +409,7 @@ class CompositeDeviceTracker(TrackerEntity, RestoreEntity):
         gps_accuracy: int | None = None,
         battery: int | None = None,
         attributes: dict | None = None,
-        source_type: str | None = SOURCE_TYPE_GPS,
+        source_type: str | None = source_type_gps,
         picture: str | None | UndefinedType = UNDEFINED,
     ) -> None:
         """Process update from CompositeScanner."""

--- a/custom_components/composite/device_tracker.py
+++ b/custom_components/composite/device_tracker.py
@@ -71,6 +71,8 @@ from .const import (
     CONF_REQ_MOVEMENT,
     CONF_TIME_AS,
     CONF_TRACKERS,
+    DATA_LEGACY_WARNED,
+    DATA_TF,
     DOMAIN,
     TIME_AS_OPTS,
     TZ_DEVICE_LOCAL,
@@ -141,30 +143,32 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(COMPOSITE_TRACKER)
 def setup_scanner(hass, config, see, discovery_info=None):
     """Set up a device scanner."""
     CompositeScanner(hass, config, see)
-    _LOGGER.warning(
-        '"%s: %s" under %s is deprecated. Move to "%s: %s"',
-        CONF_PLATFORM,
-        DOMAIN,
-        DT_DOMAIN,
-        DOMAIN,
-        CONF_TRACKERS,
-    )
-    pn_async_create(
-        hass,
-        title="Composite configuration has changed",
-        message="```text\n"
-        f"{DT_DOMAIN}:\n"
-        f"- platform: {DOMAIN}\n"
-        "  <TRACKER CONFIG>\n\n"
-        "```\n"
-        "is deprecated. Move to:\n\n"
-        "```text\n"
-        f"{DOMAIN}:\n"
-        f"  {CONF_TRACKERS}:\n"
-        "  - <TRACKER_CONFIG>\n"
-        "```\n\n"
-        "Also remove entries from known_devices.yaml.",
-    )
+    if not hass.data[DOMAIN][DATA_LEGACY_WARNED]:
+        _LOGGER.warning(
+            '"%s: %s" under %s is deprecated. Move to "%s: %s"',
+            CONF_PLATFORM,
+            DOMAIN,
+            DT_DOMAIN,
+            DOMAIN,
+            CONF_TRACKERS,
+        )
+        pn_async_create(
+            hass,
+            title="Composite configuration has changed",
+            message="```text\n"
+            f"{DT_DOMAIN}:\n"
+            f"- platform: {DOMAIN}\n"
+            "  <TRACKER CONFIG>\n\n"
+            "```\n"
+            "is deprecated. Move to:\n\n"
+            "```text\n"
+            f"{DOMAIN}:\n"
+            f"  {CONF_TRACKERS}:\n"
+            "  - <TRACKER_CONFIG>\n"
+            "```\n\n"
+            "Also remove entries from known_devices.yaml.",
+        )
+        hass.data[DOMAIN][DATA_LEGACY_WARNED] = True
     return True
 
 
@@ -322,7 +326,7 @@ class CompositeScanner:
         self._entity_id = f"{DT_DOMAIN}.{self._dev_id}"
         self._time_as = config[CONF_TIME_AS]
         if self._time_as in [TZ_DEVICE_UTC, TZ_DEVICE_LOCAL]:
-            self._tf = hass.data[DOMAIN]
+            self._tf = hass.data[DOMAIN][DATA_TF]
         self._req_movement = config[CONF_REQ_MOVEMENT]
         self._lock = threading.Lock()
 

--- a/custom_components/composite/device_tracker.py
+++ b/custom_components/composite/device_tracker.py
@@ -1,8 +1,12 @@
 """A Device Tracker platform that combines one or more device trackers."""
+from __future__ import annotations
+
 import asyncio
-from datetime import datetime, timedelta
+from collections.abc import Callable, Iterable, MutableMapping
+from datetime import datetime, timedelta, tzinfo
 import logging
 import threading
+from typing import Any, cast
 
 import voluptuous as vol
 
@@ -11,7 +15,7 @@ from homeassistant.components.device_tracker import (
     ATTR_BATTERY,
     ATTR_SOURCE_TYPE,
     DOMAIN as DT_DOMAIN,
-    PLATFORM_SCHEMA,
+    PLATFORM_SCHEMA as PLATFORM_SCHEMA_BASE,
 )
 
 # SourceType was new in 2022.9
@@ -43,6 +47,7 @@ from homeassistant.components.persistent_notification import (
 )
 from homeassistant.components.zone import ENTITY_ID_HOME
 from homeassistant.components.zone import async_active_zone
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     ATTR_BATTERY_CHARGING,
     ATTR_BATTERY_LEVEL,
@@ -60,8 +65,11 @@ from homeassistant.const import (
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
 )
+from homeassistant.core import CALLBACK_TYPE, HomeAssistant, State
 import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.event import track_state_change
+from homeassistant.helpers.typing import GPSType
 from homeassistant.util.async_ import run_callback_threadsafe
 import homeassistant.util.dt as dt_util
 from homeassistant.util.location import distance
@@ -108,8 +116,9 @@ SOURCE_TYPE_NON_GPS = (
 )
 
 
-def _entities(entities):
-    result = []
+def _entities(entities: list[str | dict]) -> list[dict]:
+    """Convert entity ID to dict of entity & all_states."""
+    result: list[dict] = []
     for entity in entities:
         if isinstance(entity, dict):
             result.append(entity)
@@ -138,10 +147,15 @@ COMPOSITE_TRACKER = {
     vol.Optional(CONF_TIME_AS, default=TIME_AS_OPTS[0]): vol.In(TIME_AS_OPTS),
     vol.Optional(CONF_REQ_MOVEMENT, default=False): cv.boolean,
 }
-PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(COMPOSITE_TRACKER)
+PLATFORM_SCHEMA = PLATFORM_SCHEMA_BASE.extend(COMPOSITE_TRACKER)
 
 
-def setup_scanner(hass, config, see, discovery_info=None):
+def setup_scanner(
+    hass: HomeAssistant,
+    config: dict,
+    see: Callable[..., None],
+    discovery_info: dict[str, Any] | None = None,
+) -> bool:
     """Set up a device scanner."""
     CompositeScanner(hass, config, see)
     if not hass.data[DOMAIN][DATA_LEGACY_WARNED]:
@@ -173,19 +187,22 @@ def setup_scanner(hass, config, see, discovery_info=None):
     return True
 
 
-async def async_setup_entry(hass, entry, async_add_entities):
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
     """Set up the device tracker platform."""
     async_add_entities([CompositeDeviceTracker(entry)])
 
 
-def nearest_second(time):
+def nearest_second(time: datetime) -> datetime:
     """Round time to nearest second."""
     return time.replace(microsecond=0) + timedelta(
         seconds=0 if time.microsecond < 500000 else 1
     )
 
 
-def _config_from_entry(entry):
+def _config_from_entry(entry: ConfigEntry) -> dict | None:
+    """Get CompositeScanner config from config entry."""
     if not entry.options:
         return None
     scanner_config = {CONF_NAME: entry.data[CONF_ID]}
@@ -196,22 +213,24 @@ def _config_from_entry(entry):
 class CompositeDeviceTracker(TrackerEntity):
     """Composite Device Tracker."""
 
-    _attr_extra_state_attributes = None
-    _battery_level = None
-    _source_type = None
+    _attr_extra_state_attributes: MutableMapping[
+        str, Any
+    ] | None = None  # type: ignore[assignment]
+    _battery_level: int | None = None
+    _source_type: str | None = None
     _location_accuracy = 0
-    _location_name = None
-    _latitude = None
-    _longitude = None
-    _scanner = None
+    _location_name: str | None = None
+    _latitude: float | None = None
+    _longitude: float | None = None
+    _scanner: CompositeScanner | None = None
 
-    def __init__(self, entry):
+    def __init__(self, entry: ConfigEntry) -> None:
         """Initialize Composite Device Tracker."""
-        self._attr_name = entry.data[CONF_NAME]
-        id = entry.data[CONF_ID]
+        self._attr_name: str = entry.data[CONF_NAME]
+        id: str = entry.data[CONF_ID]
         self._attr_unique_id = id
         self.entity_id = f"{DT_DOMAIN}.{id}"
-        self._scanner_config = _config_from_entry(entry)
+        self._scanner_config: dict | None = _config_from_entry(entry)
         self._lock = asyncio.Lock()
 
         self.async_on_remove(
@@ -219,86 +238,80 @@ class CompositeDeviceTracker(TrackerEntity):
         )
 
     @property
-    def unique_id(self):
-        """Return a unique ID."""
-        return self._attr_unique_id
-
-    @property
-    def name(self):
-        """Return the name of the entity."""
-        return self._attr_name
-
-    @property
-    def force_update(self):
+    def force_update(self) -> bool:
         """Return True if state updates should be forced."""
         return False
 
     @property
-    def battery_level(self):
+    def battery_level(self) -> int | None:
         """Return the battery level of the device."""
         return self._battery_level
 
     @property
-    def source_type(self):
+    def source_type(self) -> str | None:  # type: ignore[override]
         """Return the source type of the device."""
         return self._source_type
 
     @property
-    def location_accuracy(self):
+    def location_accuracy(self) -> int:
         """Return the location accuracy of the device."""
         return self._location_accuracy
 
     @property
-    def location_name(self):
+    def location_name(self) -> str | None:
         """Return a location name for the current location of the device."""
         return self._location_name
 
     @property
-    def latitude(self):
+    def latitude(self) -> float | None:
         """Return the latitude value of the device."""
         return self._latitude
 
     @property
-    def longitude(self):
+    def longitude(self) -> float | None:
         """Rerturn the longitude value of the device."""
         return self._longitude
 
-    async def async_added_to_hass(self):
+    async def async_added_to_hass(self) -> None:
         """Run when entity about to be added to hass."""
         await super().async_added_to_hass()
         async with self._lock:
             await self._setup_scanner()
 
-    async def async_will_remove_from_hass(self):
+    async def async_will_remove_from_hass(self) -> None:
         """Run when entity will be removed from hass."""
         async with self._lock:
             await self._shutdown_scanner()
         await super().async_will_remove_from_hass()
 
-    async def _setup_scanner(self):
+    async def _setup_scanner(self) -> None:
         """Set up device scanner."""
         if not self._scanner_config or self._scanner:
             return
 
-        def setup_scanner():
+        def setup_scanner() -> None:
             """Set up device scanner."""
-            self._scanner = CompositeScanner(self.hass, self._scanner_config, self._see)
+            self._scanner = CompositeScanner(
+                self.hass, cast(dict, self._scanner_config), self._see
+            )
 
         await self.hass.async_add_executor_job(setup_scanner)
 
-    async def _shutdown_scanner(self):
+    async def _shutdown_scanner(self) -> None:
         """Shutdown device scanner."""
         if not self._scanner:
             return
 
-        def shutdown_scanner():
+        def shutdown_scanner() -> None:
             """Shutdown device scanner."""
-            self._scanner.shutdown()
+            cast(CompositeScanner, self._scanner).shutdown()
             self._scanner = None
 
         await self.hass.async_add_executor_job(shutdown_scanner)
 
-    async def _async_config_entry_updated(self, _, entry):
+    async def _async_config_entry_updated(
+        self, hass: HomeAssistant, entry: ConfigEntry
+    ) -> None:
         """Run when the config entry has been updated."""
         new_scanner_config = _config_from_entry(entry)
         if new_scanner_config == self._scanner_config:
@@ -309,8 +322,16 @@ class CompositeDeviceTracker(TrackerEntity):
             await self._setup_scanner()
 
     def _see(
-        self, dev_id, location_name, gps, gps_accuracy, battery, attributes, source_type
-    ):
+        self,
+        *,
+        dev_id: str | None = None,
+        location_name: str | None = None,
+        gps: GPSType | None = None,
+        gps_accuracy: int | None = None,
+        battery: int | None = None,
+        attributes: dict | None = None,
+        source_type: str | None = SOURCE_TYPE_GPS,
+    ) -> None:
         """Process update from CompositeScanner."""
         self._battery_level = battery
         self._source_type = source_type
@@ -328,18 +349,20 @@ class CompositeDeviceTracker(TrackerEntity):
 class CompositeScanner:
     """Composite device scanner."""
 
-    _prev_seen = None
-    _remove = None
+    _prev_seen: datetime | None = None
+    _remove: CALLBACK_TYPE | None = None
 
-    def __init__(self, hass, config, see):
+    def __init__(
+        self, hass: HomeAssistant, config: dict, see: Callable[..., None]
+    ) -> None:
         """Initialize CompositeScanner."""
         self._hass = hass
         self._see = see
-        entities = config[CONF_ENTITY_ID]
-        self._entities = {}
-        entity_ids = []
+        entities: list[dict[str, Any]] = config[CONF_ENTITY_ID]
+        self._entities: dict[str, dict[str, Any]] = {}
+        entity_ids: list[str] = []
         for entity in entities:
-            entity_id = entity[CONF_ENTITY]
+            entity_id: str = entity[CONF_ENTITY]
             self._entities[entity_id] = {
                 USE_ALL_STATES: entity[CONF_ALL_STATES],
                 STATUS: INACTIVE,
@@ -348,12 +371,12 @@ class CompositeScanner:
                 DATA: None,
             }
             entity_ids.append(entity_id)
-        self._dev_id = config[CONF_NAME]
+        self._dev_id: str = config[CONF_NAME]
         self._entity_id = f"{DT_DOMAIN}.{self._dev_id}"
-        self._time_as = config[CONF_TIME_AS]
+        self._time_as: str = config[CONF_TIME_AS]
         if self._time_as in [TZ_DEVICE_UTC, TZ_DEVICE_LOCAL]:
             self._tf = hass.data[DOMAIN][DATA_TF]
-        self._req_movement = config[CONF_REQ_MOVEMENT]
+        self._req_movement: bool = config[CONF_REQ_MOVEMENT]
         self._lock = threading.Lock()
 
         self._startup(entity_ids)
@@ -361,11 +384,11 @@ class CompositeScanner:
         for entity_id in entity_ids:
             self._update_info(entity_id, None, hass.states.get(entity_id))
 
-    def _startup(self, entity_ids):
+    def _startup(self, entity_ids: str | Iterable[str]) -> None:
         """Start updating."""
         self._remove = track_state_change(self._hass, entity_ids, self._update_info)
 
-    def shutdown(self):
+    def shutdown(self) -> None:
         """Stop updating."""
         if self._remove:
             self._remove()
@@ -373,11 +396,12 @@ class CompositeScanner:
             # In case an update started just prior to call to self._remove above, wait
             # for it to complete so that our caller will know, when we return, this
             # CompositeScanner instance is completely stopped.
-            with self._lock():
+            with self._lock:
                 pass
 
-    def _bad_entity(self, entity_id, message):
-        msg = "{} {}".format(entity_id, message)
+    def _bad_entity(self, entity_id: str, message: str) -> None:
+        """Mark entity ID as bad."""
+        msg = f"{entity_id} {message}"
         # Has there already been a warning for this entity?
         if self._entities[entity_id][STATUS] == WARNED:
             _LOGGER.error(msg)
@@ -393,12 +417,16 @@ class CompositeScanner:
             _LOGGER.debug(msg)
             self._entities[entity_id][STATUS] = ACTIVE
 
-    def _good_entity(self, entity_id, seen, source_type, data):
+    def _good_entity(
+        self, entity_id: str, seen: datetime, source_type: str, data: Any
+    ) -> None:
+        """Mark entity ID as good."""
         self._entities[entity_id].update(
             {STATUS: ACTIVE, SEEN: seen, SOURCE_TYPE: source_type, DATA: data}
         )
 
-    def _use_non_gps_data(self, entity_id, state):
+    def _use_non_gps_data(self, entity_id: str, state: str) -> bool:
+        """Determine if state should be used for non-GPS based entity."""
         if state == STATE_HOME or self._entities[entity_id][USE_ALL_STATES]:
             return True
         entities = self._entities.values()
@@ -410,14 +438,18 @@ class CompositeScanner:
             if entity[SOURCE_TYPE] in SOURCE_TYPE_NON_GPS
         )
 
-    def _dt_attr_from_utc(self, utc, tzone):
+    def _dt_attr_from_utc(self, utc: datetime, tzone: tzinfo | None) -> datetime:
+        """Determine state attribute value from datetime & timezone."""
         if self._time_as in [TZ_DEVICE_UTC, TZ_DEVICE_LOCAL] and tzone:
             return utc.astimezone(tzone)
         if self._time_as in [TZ_LOCAL, TZ_DEVICE_LOCAL]:
             return dt_util.as_local(utc)
         return utc
 
-    def _update_info(self, entity_id, old_state, new_state):
+    def _update_info(
+        self, entity_id: str, old_state: State | None, new_state: State | None
+    ) -> None:
+        """Update composite tracker from input entity state change."""
         if new_state is None or new_state.state in (STATE_UNKNOWN, STATE_UNAVAILABLE):
             return
 
@@ -427,41 +459,44 @@ class CompositeScanner:
             # new state object. Make sure last_seen is timezone aware in UTC.
             # Note that dt_util.as_utc assumes naive datetime is in local
             # timezone.
-            last_seen = new_state.attributes.get(ATTR_LAST_SEEN)
+            last_seen: datetime | str | None = new_state.attributes.get(ATTR_LAST_SEEN)
             if isinstance(last_seen, datetime):
                 last_seen = dt_util.as_utc(last_seen)
             else:
                 try:
-                    last_seen = dt_util.utc_from_timestamp(float(last_seen))
+                    last_seen = dt_util.utc_from_timestamp(float(last_seen))  # type: ignore[arg-type]
                 except (TypeError, ValueError):
                     last_seen = new_state.last_updated
 
-            old_last_seen = self._entities[entity_id][SEEN]
+            old_last_seen: datetime | None = self._entities[entity_id][SEEN]
             if old_last_seen and last_seen < old_last_seen:
                 self._bad_entity(entity_id, "last_seen went backwards")
                 return
 
             # Try to get GPS and battery data.
             try:
-                gps = (
-                    new_state.attributes[ATTR_LATITUDE],
-                    new_state.attributes[ATTR_LONGITUDE],
+                gps: GPSType | None = cast(
+                    GPSType,
+                    (
+                        new_state.attributes[ATTR_LATITUDE],
+                        new_state.attributes[ATTR_LONGITUDE],
+                    ),
                 )
             except KeyError:
                 gps = None
-            gps_accuracy = new_state.attributes.get(ATTR_GPS_ACCURACY)
-            battery = new_state.attributes.get(
+            gps_accuracy: int | None = new_state.attributes.get(ATTR_GPS_ACCURACY)
+            battery: int | None = new_state.attributes.get(
                 ATTR_BATTERY, new_state.attributes.get(ATTR_BATTERY_LEVEL)
             )
-            charging = new_state.attributes.get(
+            charging: bool | None = new_state.attributes.get(
                 ATTR_BATTERY_CHARGING, new_state.attributes.get(ATTR_CHARGING)
             )
             # Don't use location_name unless we have to.
-            location_name = None
+            location_name: str | None = None
 
             # What type of tracker is this?
             if new_state.domain == BS_DOMAIN:
-                source_type = SOURCE_TYPE_BINARY_SENSOR
+                source_type: str | None = SOURCE_TYPE_BINARY_SENSOR
             else:
                 source_type = new_state.attributes.get(ATTR_SOURCE_TYPE)
 
@@ -477,7 +512,7 @@ class CompositeScanner:
                     return
 
                 new_data = gps, gps_accuracy
-                old_data = self._entities[entity_id][DATA]
+                old_data: tuple[GPSType, int] | None = self._entities[entity_id][DATA]
                 if old_data:
                     if last_seen == old_last_seen and new_data == old_data:
                         return
@@ -487,12 +522,13 @@ class CompositeScanner:
                 if (
                     self._req_movement
                     and old_data
-                    and distance(gps[0], gps[1], old_gps[0], old_gps[1])
+                    and cast(float, distance(gps[0], gps[1], old_gps[0], old_gps[1]))
                     <= gps_accuracy + old_acc
                 ):
                     _LOGGER.debug(
-                        "For {} skipping update from {}: "
-                        "not enough movement".format(self._entity_id, entity_id)
+                        "For %s skipping update from %s: not enough movement",
+                        self._entity_id,
+                        entity_id,
                     )
                     return
 
@@ -505,7 +541,7 @@ class CompositeScanner:
                     else:
                         state = STATE_NOT_HOME
 
-                self._good_entity(entity_id, last_seen, source_type, state)
+                self._good_entity(entity_id, last_seen, cast(str, source_type), state)
 
                 if not self._use_non_gps_data(entity_id, state):
                     return
@@ -517,19 +553,22 @@ class CompositeScanner:
                 # 'zone.home'.
                 cur_state = self._hass.states.get(self._entity_id)
                 try:
-                    cur_lat = cur_state.attributes[ATTR_LATITUDE]
-                    cur_lon = cur_state.attributes[ATTR_LONGITUDE]
-                    cur_acc = cur_state.attributes[ATTR_GPS_ACCURACY]
+                    cur_lat: float = cast(State, cur_state).attributes[ATTR_LATITUDE]
+                    cur_lon: float = cast(State, cur_state).attributes[ATTR_LONGITUDE]
+                    cur_acc: int = cast(State, cur_state).attributes[ATTR_GPS_ACCURACY]
                     cur_gps_is_home = (
-                        run_callback_threadsafe(
-                            self._hass.loop,
-                            async_active_zone,
-                            self._hass,
-                            cur_lat,
-                            cur_lon,
-                            cur_acc,
+                        cast(
+                            State,
+                            run_callback_threadsafe(
+                                self._hass.loop,
+                                async_active_zone,
+                                self._hass,
+                                cur_lat,
+                                cur_lon,
+                                cur_acc,
+                            )
+                            .result(),
                         )
-                        .result()
                         .entity_id
                         == ENTITY_ID_HOME
                     )
@@ -560,7 +599,7 @@ class CompositeScanner:
                 elif state == STATE_HOME and (
                     cur_state is None or cur_state.state != STATE_HOME
                 ):
-                    gps = (self._hass.config.latitude, self._hass.config.longitude)
+                    gps = self._hass.config.latitude, self._hass.config.longitude
                     gps_accuracy = 0
                     source_type = source_type_gps
                 # Otherwise, don't use any GPS data, but set location_name to
@@ -569,32 +608,32 @@ class CompositeScanner:
                     location_name = state
 
             else:
-                self._bad_entity(
-                    entity_id, "unsupported source_type: {}".format(source_type)
-                )
+                self._bad_entity(entity_id, f"unsupported source_type: {source_type}")
                 return
 
             # Is this newer info than last update?
             if self._prev_seen and last_seen <= self._prev_seen:
                 _LOGGER.debug(
-                    "For {} skipping update from {}: "
-                    "last_seen not newer than previous update ({} <= {})".format(
-                        self._entity_id, entity_id, last_seen, self._prev_seen
-                    )
+                    "For %s skipping update from %s: "
+                    "last_seen not newer than previous update (%s) <= (%s)",
+                    self._entity_id,
+                    entity_id,
+                    last_seen,
+                    self._prev_seen,
                 )
                 return
 
             _LOGGER.debug("Updating %s from %s", self._entity_id, entity_id)
 
-            tzone = None
+            tzone: tzinfo | None = None
             if self._time_as in [TZ_DEVICE_UTC, TZ_DEVICE_LOCAL]:
-                tzname = None
+                tzname: str | None = None
                 if gps:
                     # timezone_at will return a string or None.
                     tzname = self._tf.timezone_at(lng=gps[1], lat=gps[0])
                     # get_time_zone will return a tzinfo or None.
-                    tzone = dt_util.get_time_zone(tzname)
-                attrs = {ATTR_TIME_ZONE: tzname or STATE_UNKNOWN}
+                    tzone = dt_util.get_time_zone(tzname) if tzname else None
+                attrs: dict[str, Any] = {ATTR_TIME_ZONE: tzname or STATE_UNKNOWN}
             else:
                 attrs = {}
 

--- a/custom_components/composite/manifest.json
+++ b/custom_components/composite/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "composite",
   "name": "Composite",
-  "version": "2.4.0b2",
+  "version": "2.4.0b3",
   "documentation": "https://github.com/pnbruckner/ha-composite-tracker/blob/entity-based/README.md",
   "issue_tracker": "https://github.com/pnbruckner/ha-composite-tracker/issues",
   "requirements": [],

--- a/custom_components/composite/manifest.json
+++ b/custom_components/composite/manifest.json
@@ -1,8 +1,8 @@
 {
   "domain": "composite",
   "name": "Composite",
-  "version": "2.4.0b0",
-  "documentation": "https://github.com/pnbruckner/ha-composite-tracker/blob/master/README.md",
+  "version": "2.4.0b1",
+  "documentation": "https://github.com/pnbruckner/ha-composite-tracker/blob/entity-based/README.md",
   "issue_tracker": "https://github.com/pnbruckner/ha-composite-tracker/issues",
   "requirements": [],
   "dependencies": [],

--- a/custom_components/composite/manifest.json
+++ b/custom_components/composite/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "composite",
   "name": "Composite",
-  "version": "2.4.0b1",
+  "version": "2.4.0b2",
   "documentation": "https://github.com/pnbruckner/ha-composite-tracker/blob/entity-based/README.md",
   "issue_tracker": "https://github.com/pnbruckner/ha-composite-tracker/issues",
   "requirements": [],

--- a/custom_components/composite/manifest.json
+++ b/custom_components/composite/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "composite",
   "name": "Composite",
-  "version": "2.4.0b4",
+  "version": "2.4.0b5",
   "documentation": "https://github.com/pnbruckner/ha-composite-tracker/blob/entity-based/README.md",
   "issue_tracker": "https://github.com/pnbruckner/ha-composite-tracker/issues",
   "requirements": [],

--- a/custom_components/composite/manifest.json
+++ b/custom_components/composite/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "composite",
   "name": "Composite",
-  "version": "2.4.0b3",
+  "version": "2.4.0b4",
   "documentation": "https://github.com/pnbruckner/ha-composite-tracker/blob/entity-based/README.md",
   "issue_tracker": "https://github.com/pnbruckner/ha-composite-tracker/issues",
   "requirements": [],

--- a/custom_components/composite/manifest.json
+++ b/custom_components/composite/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "composite",
   "name": "Composite",
-  "version": "2.4.0b5",
+  "version": "2.4.0b6",
   "documentation": "https://github.com/pnbruckner/ha-composite-tracker/blob/entity-based/README.md",
   "issue_tracker": "https://github.com/pnbruckner/ha-composite-tracker/issues",
   "requirements": [],

--- a/custom_components/composite/manifest.json
+++ b/custom_components/composite/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "composite",
   "name": "Composite",
-  "version": "2.4.0b6",
+  "version": "2.4.0b7",
   "documentation": "https://github.com/pnbruckner/ha-composite-tracker/blob/entity-based/README.md",
   "issue_tracker": "https://github.com/pnbruckner/ha-composite-tracker/issues",
   "requirements": [],

--- a/custom_components/composite/manifest.json
+++ b/custom_components/composite/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "composite",
   "name": "Composite",
-  "version": "2.3.0",
+  "version": "2.4.0b0",
   "documentation": "https://github.com/pnbruckner/ha-composite-tracker/blob/master/README.md",
   "issue_tracker": "https://github.com/pnbruckner/ha-composite-tracker/issues",
   "requirements": [],


### PR DESCRIPTION
- Deprecate support for "legacy" trackers.
- Create persistent notification to change config from device_tracker -> composite.
- Support HomeAssistant version 2021.12 or newer & Python 3.9 or newer.
- Add default_options.
- Add entity use_picture option.
- Restore state after HA restart.