### PR TITLE
Add support for last_timestamp attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Composite Device Tracker
 
-This integration creates a composite `device_tracker` entity from one or more other device trackers and/or binary sensors. It will update whenever one of the watched entities updates, taking the `last_seen`/`last_updated` (and possibly GPS and battery) data from the changing entity. The result can be a more accurate and up-to-date device tracker if the "input" entities update irregularly.
+This integration creates a composite `device_tracker` entity from one or more other device trackers and/or binary sensors. It will update whenever one of the watched entities updates, taking the `last_seen`, `last_timestamp` or`last_updated` (and possibly GPS and battery) data from the changing entity. The result can be a more accurate and up-to-date device tracker if the "input" entities update irregularly.
 
 Currently `device_tracker` entities with a `source_type` of `bluetooth`, `bluetooth_le`, `gps` or `router` are supported, as well as `binary_sensor` entities.
 
@@ -124,7 +124,7 @@ Watched GPS-based devices must have, at a minimum, the following attributes: `la
 
 For watched non-GPS-based devices, which states are used and whether any GPS data (if present) is used depends on several factors. E.g., if GPS-based devices are in use then the 'not_home'/'off' state of non-GPS-based devices will be ignored (unless `all_states` was specified as `true` for that entity.) If only non-GPS-based devices are in use, then the composite device will be 'home' if any of the watched devices are 'home'/'on', and will be 'not_home' only when _all_ the watched devices are 'not_home'/'off'.
 
-If a watched device has a `last_seen` attribute, that will be used in the composite device. If not, then `last_updated` from the entity's state will be used instead.
+If a watched device has a `last_seen` or `last_timestamp` attribute, that will be used in the composite device. If not, then `last_updated` from the entity's state will be used instead.
 
 If a watched device has a `battery` or `battery_level` attribute, that will be used to update the composite device's `battery` attribute. If it has a `battery_charging` or `charging` attribute, that will be used to udpate the composite device's `battery_charging` attribute.
 

--- a/custom_components/composite/manifest.json
+++ b/custom_components/composite/manifest.json
@@ -1,8 +1,8 @@
 {
   "domain": "composite",
   "name": "Composite",
-  "version": "2.7.1",
-  "documentation": "https://github.com/pnbruckner/ha-composite-tracker/blob/master/README.md",
+  "version": "2.8.0b0",
+  "documentation": "https://github.com/pnbruckner/ha-composite-tracker/blob/last_timestamp/README.md",
   "issue_tracker": "https://github.com/pnbruckner/ha-composite-tracker/issues",
   "requirements": [],
   "dependencies": [],

--- a/custom_components/composite/sensor.py
+++ b/custom_components/composite/sensor.py
@@ -13,6 +13,7 @@ from homeassistant.components.sensor import (
 )
 
 # SensorDeviceClass.SPEED was new in 2022.10
+speed_sensor_device_class: str | None
 try:
     from homeassistant.components.sensor import SensorDeviceClass
 
@@ -34,6 +35,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_ID, CONF_NAME
 
 # UnitOfSpeed was new in 2022.11
+meters_per_second: str
 try:
     from homeassistant.const import UnitOfSpeed
 
@@ -54,8 +56,8 @@ from .const import ATTR_ANGLE, ATTR_DIRECTION, SIG_COMPOSITE_SPEED
 class CompositeSensorEntityDescription(SensorEntityDescription):
     """Composite sensor entity description."""
 
-    id: str = None
-    signal: str = None
+    id: str = None  # type: ignore[assignment]
+    signal: str = None  # type: ignore[assignment]
 
 
 async def async_setup_entry(
@@ -73,7 +75,7 @@ async def async_setup_entry(
         signal=f"{SIG_COMPOSITE_SPEED}-{entry.data[CONF_ID]}",
     )
     if speed_sensor_device_class:
-        entity_description.device_class = speed_sensor_device_class
+        entity_description.device_class = speed_sensor_device_class  # type: ignore[assignment]
         entity_description.native_unit_of_measurement = meters_per_second
     async_add_entities([CompositeSensor(hass, entity_description)])
 
@@ -93,7 +95,7 @@ class CompositeSensor(SensorEntity):
         self.entity_description = entity_description
 
         @callback
-        def set_unit_of_measurement(event: Event = None) -> None:
+        def set_unit_of_measurement(event: Event | None = None) -> None:
             """Set unit of measurement based on HA config."""
             if hass.config.units is METRIC_SYSTEM:
                 uom = SPEED_KILOMETERS_PER_HOUR
@@ -132,7 +134,7 @@ class CompositeSensor(SensorEntity):
             ]
 
         if value and self._to_unit:
-            value = f"{convert(value, LENGTH_METERS, self._to_unit) * (60 * 60):0.1f}"
+            value = f"{convert(value, LENGTH_METERS, self._to_unit) * (60 * 60):0.1f}"  # type: ignore[assignment]
         self._attr_native_value = value
         self.entity_description.force_update = bool(value)
         self._attr_extra_state_attributes = {

--- a/info.md
+++ b/info.md
@@ -1,6 +1,6 @@
 # Composite Device Tracker
 
-This integration creates a composite `device_tracker` entity from one or more other device trackers and/or binary sensors. It will update whenever one of the watched entities updates, taking the `last_seen`/`last_updated` (and possibly GPS and battery) data from the changing entity. The result can be a more accurate and up-to-date device tracker if the "input" entities update irregularly.
+This integration creates a composite `device_tracker` entity from one or more other device trackers and/or binary sensors. It will update whenever one of the watched entities updates, taking the `last_seen`, `last_timestamp` or `last_updated` (and possibly GPS and battery) data from the changing entity. The result can be a more accurate and up-to-date device tracker if the "input" entities update irregularly.
 
 Currently `device_tracker` entities with a `source_type` of `bluetooth`, `bluetooth_le`, `gps` or `router` are supported, as well as `binary_sensor` entities.
 


### PR DESCRIPTION
Some device tracker integrations (e.g., tile) include a last_timestamp attribute that records when the location information was last updated. Use this the same way as the last_seen attribute of other integrations.

May help address #33.