### PR TITLE
Change timezonefinder defaults

### DIFF
--- a/custom_components/composite/__init__.py
+++ b/custom_components/composite/__init__.py
@@ -40,7 +40,7 @@ from .config_flow import split_conf
 from .device_tracker import COMPOSITE_TRACKER
 
 CONF_TZ_FINDER = "tz_finder"
-DEFAULT_TZ_FINDER = "timezonefinderL==4.0.2"
+DEFAULT_TZ_FINDER = "timezonefinder==6.2.0"
 CONF_TZ_FINDER_CLASS = "tz_finder_class"
 PLATFORMS = [Platform.DEVICE_TRACKER, Platform.SENSOR]
 TZ_FINDER_CLASS_OPTS = ["TimezoneFinder", "TimezoneFinderL"]
@@ -84,7 +84,7 @@ CONFIG_SCHEMA = vol.Schema(
                 {
                     vol.Optional(CONF_TZ_FINDER, default=DEFAULT_TZ_FINDER): cv.string,
                     vol.Optional(
-                        CONF_TZ_FINDER_CLASS, default=TZ_FINDER_CLASS_OPTS[0]
+                        CONF_TZ_FINDER_CLASS, default=TZ_FINDER_CLASS_OPTS[1]
                     ): vol.In(TZ_FINDER_CLASS_OPTS),
                     vol.Optional(CONF_DEFAULT_OPTIONS, default=dict): vol.Schema(
                         {


### PR DESCRIPTION
The default time zone finder package, timezonefinderL, lists importlib-resouces as a requirement, but does not specify a version. That package recently changed such that it no longer provides a method timezonefinderL used, namely open_binary. This indirectly causes the startup of the composite integration to fail if it is configured to use device_or_utc or device_or_local.

Since timezonefinderL hasn't been updated in over four years, and was effectively replaced by newer versions of timezonefinder, change this integration's defaults to use:

Package: timezonefinder==6.2.0
Class: TimezoneFinderL

Fixes #47