### PR TITLE
Add optional driving state

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,34 +6,42 @@ It will also create a `sensor` entity that indicates the speed of the device.
 
 Currently any entity that has "GPS" attributes (`gps_accuracy` or `acc`, and either `latitude` & `longitude` or `lat` & `lon`), or any `device_tracker` entity with a `source_type` attribute of `bluetooth`, `bluetooth_le`, `gps` or `router`, or any `binary_sensor` entity, can be used as an input entity.
 
-## Breaking Change
-
-- All time zone related features have been removed. See https://github.com/pnbruckner/ha-entity-tz for an integration that replaces those features, and more.
-- Any tracker entry removed from YAML configuration will be removed from the system.
-- `trackers` in YAML configuration must have at least one entry.
-- The `entity_id` attribute has been changed to `entities`. `entity_id` did not show up in the attribute list in the UI.
-
 ## Installation
-### With HACS
+
+<details>
+<summary>With HACS</summary>
+
 [![hacs_badge](https://img.shields.io/badge/HACS-Custom-41BDF5.svg)](https://hacs.xyz/)
 
 You can use HACS to manage the installation and provide update notifications.
 
-1. Add this repo as a [custom repository](https://hacs.xyz/docs/faq/custom_repositories/):
+1. Add this repo as a [custom repository](https://hacs.xyz/docs/faq/custom_repositories/).
+   It should then appear as a new integration. Click on it. If necessary, search for "composite".
 
-```text
-https://github.com/pnbruckner/ha-composite-tracker
-```
+   ```text
+   https://github.com/pnbruckner/ha-composite-tracker
+   ```
+   Or use this button:
+   
+   [![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=pnbruckner&repository=ha-composite-tracker&category=integration)
 
-2. Install the integration using the appropriate button on the HACS Integrations page. Search for "composite".
 
-### Manual
+1. Download the integration using the appropriate button.
+
+</details>
+
+<details>
+<summary>Manual</summary>
 
 Place a copy of the files from [`custom_components/composite`](custom_components/composite)
 in `<config>/custom_components/composite`,
 where `<config>` is your Home Assistant configuration directory.
 
 >__NOTE__: When downloading, make sure to use the `Raw` button from each file's page.
+
+</details>
+
+After it has been downloaded you will need to restart Home Assistant.
 
 ### Versions
 
@@ -57,6 +65,7 @@ composite:
 
 - **default_options** (*Optional*): Defines default values for corresponding options under **trackers**.
   - **require_movement** (*Optional*): Default is `false`.
+  - **driving_speed** (*Optional*)
 
 - **trackers**: The list of composite trackers to create. For each entry see [Tracker entries](#tracker-entries).
 
@@ -66,6 +75,7 @@ composite:
 - **name**: Friendly name of composite device.
 - **id** (*Optional*): Object ID (i.e., part of entity ID after the dot) of composite device. If not supplied, then object ID will be generated from the `name` variable. For example, `My Name` would result in a tracker entity ID of `device_tracker.my_name`. The speed sensor's object ID will be the same as for the device tracker, but with a suffix of "`_speed`" added (e.g., `sensor.my_name_speed`.)
 - **require_movement** (*Optional*): `true` or `false`. If `true`, will skip update from a GPS-based tracker if it has not moved. Specifically, if circle defined by new GPS coordinates and accuracy overlaps circle defined by previous GPS coordinates and accuracy then update will be ignored.
+- **driving_speed** (*Optional*): Defines a driving speed threshold (in MPH or KPH, depending on general unit system setting.) If set, and current speed is at or above this value, and tracker is not in a zone, then the state of the tracker will be set to `driving`.
 
 #### Entity Dictionary
 
@@ -109,8 +119,10 @@ direction | Compass heading of movement direction (if moving.)
 composite:
   default_options:
     require_movement: true
+    driving_speed: 15
   trackers:
     - name: Me
+      driving_speed: 20
       entity_id:
         - entity: device_tracker.platform1_me
           use_picture: true

--- a/custom_components/composite/__init__.py
+++ b/custom_components/composite/__init__.py
@@ -27,6 +27,7 @@ from homeassistant.util import slugify
 from .const import (
     CONF_ALL_STATES,
     CONF_DEFAULT_OPTIONS,
+    CONF_DRIVING_SPEED,
     CONF_ENTITY,
     CONF_REQ_MOVEMENT,
     CONF_TIME_AS,
@@ -102,10 +103,13 @@ def _defaults(config: dict) -> dict:
         unsupported_cfgs.add(CONF_TIME_AS)
 
     def_req_mv = config[CONF_DEFAULT_OPTIONS][CONF_REQ_MOVEMENT]
+    def_drv_sp = config[CONF_DEFAULT_OPTIONS].get(CONF_DRIVING_SPEED)
     for tracker in config[CONF_TRACKERS]:
         if tracker.pop(CONF_TIME_AS, None):
             unsupported_cfgs.add(CONF_TIME_AS)
         tracker[CONF_REQ_MOVEMENT] = tracker.get(CONF_REQ_MOVEMENT, def_req_mv)
+        if CONF_DRIVING_SPEED not in tracker and def_drv_sp is not None:
+            tracker[CONF_DRIVING_SPEED] = def_drv_sp
 
     if unsupported_cfgs:
         _LOGGER.warning(
@@ -115,6 +119,7 @@ def _defaults(config: dict) -> dict:
             ", ".join(sorted(unsupported_cfgs)),
         )
 
+    del config[CONF_DEFAULT_OPTIONS]
     return config
 
 
@@ -141,6 +146,7 @@ _TRACKER = {
     vol.Required(CONF_ENTITY_ID): _ENTITIES,
     vol.Optional(CONF_TIME_AS): cv.string,
     vol.Optional(CONF_REQ_MOVEMENT): cv.boolean,
+    vol.Optional(CONF_DRIVING_SPEED): vol.Coerce(float),
 }
 CONFIG_SCHEMA = vol.Schema(
     {
@@ -155,6 +161,7 @@ CONFIG_SCHEMA = vol.Schema(
                             vol.Optional(
                                 CONF_REQ_MOVEMENT, default=DEF_REQ_MOVEMENT
                             ): cv.boolean,
+                            vol.Optional(CONF_DRIVING_SPEED): vol.Coerce(float),
                         }
                     ),
                     vol.Required(CONF_TRACKERS, default=list): vol.All(

--- a/custom_components/composite/const.py
+++ b/custom_components/composite/const.py
@@ -5,6 +5,7 @@ SIG_COMPOSITE_SPEED = "composite_speed"
 
 CONF_ALL_STATES = "all_states"
 CONF_DEFAULT_OPTIONS = "default_options"
+CONF_DRIVING_SPEED = "driving_speed"
 CONF_ENTITY = "entity"
 CONF_REQ_MOVEMENT = "require_movement"
 CONF_TIME_AS = "time_as"
@@ -22,3 +23,5 @@ ATTR_DIRECTION = "direction"
 ATTR_ENTITIES = "entities"
 ATTR_LAT = "lat"
 ATTR_LON = "lon"
+
+STATE_DRIVING = "driving"

--- a/custom_components/composite/device_tracker.py
+++ b/custom_components/composite/device_tracker.py
@@ -19,7 +19,6 @@ from homeassistant.components.device_tracker import (
     SourceType,
 )
 from homeassistant.components.device_tracker.config_entry import TrackerEntity
-from homeassistant.components.zone import ENTITY_ID_HOME, async_active_zone
 from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
 from homeassistant.const import (
     ATTR_BATTERY_CHARGING,
@@ -54,12 +53,14 @@ from .const import (
     ATTR_LAT,
     ATTR_LON,
     CONF_ALL_STATES,
+    CONF_DRIVING_SPEED,
     CONF_ENTITY,
     CONF_REQ_MOVEMENT,
     CONF_USE_PICTURE,
     MIN_ANGLE_SPEED,
     MIN_SPEED_SECONDS,
     SIG_COMPOSITE_SPEED,
+    STATE_DRIVING,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -206,6 +207,7 @@ class CompositeDeviceTracker(TrackerEntity, RestoreEntity):
     _prev_seen: datetime | None = None
     _remove_track_states: Callable[[], None] | None = None
     _req_movement: bool
+    _driving_speed: float | None  # m/s
 
     def __init__(self, entry: ConfigEntry) -> None:
         """Initialize Composite Device Tracker."""
@@ -278,6 +280,7 @@ class CompositeDeviceTracker(TrackerEntity, RestoreEntity):
         """Process options from config entry."""
         options = cast(ConfigEntry, self.platform.config_entry).options
         self._req_movement = options[CONF_REQ_MOVEMENT]
+        self._driving_speed = options.get(CONF_DRIVING_SPEED)
         entity_cfgs = {
             entity_cfg[CONF_ENTITY]: entity_cfg
             for entity_cfg in options[CONF_ENTITY_ID]
@@ -489,21 +492,9 @@ class CompositeDeviceTracker(TrackerEntity, RestoreEntity):
             # Don't use new GPS data if it's not complete.
             if not gps or gps_accuracy is None:
                 gps = gps_accuracy = None
-            # Get current GPS data, if any, and determine if it is in
-            # 'zone.home'.
-            cur_state = self.hass.states.get(self.entity_id)
-            try:
-                cur_lat: float = cast(State, cur_state).attributes[ATTR_LATITUDE]
-                cur_lon: float = cast(State, cur_state).attributes[ATTR_LONGITUDE]
-                cur_acc: int = cast(State, cur_state).attributes[ATTR_GPS_ACCURACY]
-                cur_gps_is_home = (
-                    async_active_zone(
-                        self.hass, cur_lat, cur_lon, cur_acc
-                    ).entity_id  # type: ignore[union-attr]
-                    == ENTITY_ID_HOME
-                )
-            except (AttributeError, KeyError):
-                cur_gps_is_home = False
+
+            # Is current state home w/ GPS data?
+            cur_gps_is_home = self.location_name is None and self.state == STATE_HOME
 
             # It's important, for this composite tracker, to avoid the
             # component level code's "stale processing." This can be done
@@ -511,24 +502,21 @@ class CompositeDeviceTracker(TrackerEntity, RestoreEntity):
             # or 2) provide a location_name (that will be used as the new
             # state.)
 
-            # If router entity's state is 'home' and current GPS data from
-            # composite entity is available and is in 'zone.home',
-            # use it and make source_type gps.
+            # If router entity's state is 'home' and our current state is 'home' w/ GPS
+            # data, use it and make source_type gps.
             if state == STATE_HOME and cur_gps_is_home:
-                gps = cast(GPSType, (cur_lat, cur_lon))
-                gps_accuracy = cur_acc
+                gps = cast(GPSType, (self.latitude, self.longitude))
+                gps_accuracy = self.location_accuracy
                 source_type = SourceType.GPS
             # Otherwise, if new GPS data is valid (which is unlikely if
             # new state is not 'home'),
             # use it and make source_type gps.
             elif gps:
                 source_type = SourceType.GPS
-            # Otherwise, if new state is 'home' and old state is not 'home'
-            # and no GPS data, then use HA's configured Home location and
-            # make source_type gps.
-            elif state == STATE_HOME and not (
-                cur_state and cur_state.state == STATE_HOME
-            ):
+            # Otherwise, if new state is 'home' and old state is not 'home' w/ GPS data
+            # (i.e., not 'home' or no GPS data), then use HA's configured Home location
+            # and make source_type gps.
+            elif state == STATE_HOME:
                 gps = cast(
                     GPSType,
                     (self.hass.config.latitude, self.hass.config.longitude),
@@ -641,6 +629,13 @@ class CompositeDeviceTracker(TrackerEntity, RestoreEntity):
                     angle = round(degrees(atan2(lon - prev_lon, lat - prev_lat)))
                     if angle < 0:
                         angle += 360
+        if (
+            speed is not None
+            and self._driving_speed is not None
+            and speed >= self._driving_speed
+            and self.state == STATE_NOT_HOME
+        ):
+            self._location_name = STATE_DRIVING
         _LOGGER.debug("%s: Sending speed: %s m/s, angle: %s°", self.name, speed, angle)
         async_dispatcher_send(
             self.hass, f"{SIG_COMPOSITE_SPEED}-{self.unique_id}", speed, angle

--- a/custom_components/composite/manifest.json
+++ b/custom_components/composite/manifest.json
@@ -4,9 +4,9 @@
   "codeowners": ["@pnbruckner"],
   "config_flow": true,
   "dependencies": [],
-  "documentation": "https://github.com/pnbruckner/ha-composite-tracker/blob/3.0.0/README.md",
+  "documentation": "https://github.com/pnbruckner/ha-composite-tracker/blob/3.1.0b0/README.md",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/pnbruckner/ha-composite-tracker/issues",
   "requirements": [],
-  "version": "3.0.0"
+  "version": "3.1.0b0"
 }

--- a/custom_components/composite/translations/en.json
+++ b/custom_components/composite/translations/en.json
@@ -18,6 +18,7 @@
             "options": {
                 "title": "Composite Options",
                 "data": {
+                    "driving_speed": "Driving speed",
                     "entity_id": "Input entities",
                     "require_movement": "Require movement"
                 }
@@ -38,6 +39,9 @@
     "entity": {
         "device_tracker": {
             "tracker": {
+                "state": {
+                    "driving": "Driving"
+                },
                 "state_attributes": {
                     "battery_charging": {"name": "Battery charging"},
                     "entities": {"name": "Seen entities"},
@@ -68,6 +72,7 @@
             "options": {
                 "title": "Composite Options",
                 "data": {
+                    "driving_speed": "Driving speed",
                     "entity_id": "Input entities",
                     "require_movement": "Require movement"
                 }

--- a/custom_components/composite/translations/nl.json
+++ b/custom_components/composite/translations/nl.json
@@ -18,6 +18,7 @@
             "options": {
                 "title": "Samengestelde opties",
                 "data": {
+                    "driving_speed": "Rijsnelheid",
                     "entity_id": "Voer entiteiten in",
                     "require_movement": "Vereist beweging"
                 }
@@ -38,6 +39,9 @@
     "entity": {
         "device_tracker": {
             "tracker": {
+                "state": {
+                    "driving": "Rijden"
+                },
                 "state_attributes": {
                     "battery_charging": {"name": "Batterij opladen"},
                     "entities": {"name": "Entiteiten gezien"},
@@ -68,6 +72,7 @@
             "options": {
                 "title": "Samengestelde opties",
                 "data": {
+                    "driving_speed": "Rijsnelheid",
                     "entity_id": "Voer entiteiten in",
                     "require_movement": "Vereist beweging"
                 }


### PR DESCRIPTION
Add configuration option for specifying a driving speed threshold. If specified, and the speed of the entity reaches or exceeds that threshold, and the entity is not in a zone, the state of the `device_tracker` entity will become "Driving".

Closes #60 