### PR TITLE
Support Home Assistant 2024.8.3 or newer

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ After it has been downloaded you will need to restart Home Assistant.
 
 ### Versions
 
-This custom integration supports HomeAssistant versions 2023.7 or newer.
+This custom integration supports HomeAssistant versions 2024.8.3 or newer.
 
 ## Configuration
 

--- a/custom_components/composite/config.py
+++ b/custom_components/composite/config.py
@@ -64,6 +64,8 @@ def _entities(entities: list[str | dict]) -> list[dict]:
 def _entity_picture(entity_picture: str) -> str:
     """Validate entity picture.
 
+    Must be run in an executor since it might do file I/O.
+
     Can be an URL or a file in "/local".
 
     file can be "/local/file" or just "file"
@@ -204,4 +206,6 @@ async def async_validate_config(
     hass: HomeAssistant, config: ConfigType
 ) -> ConfigType | None:
     """Validate configuration."""
-    return cast(ConfigType, _CONFIG_SCHEMA(config))
+    # Perform _CONFIG_SCHEMA validation in executor since it may indirectly invoke
+    # _entity_picture which must be run in an executor because it might do file I/O.
+    return cast(ConfigType, await hass.async_add_executor_job(_CONFIG_SCHEMA, config))

--- a/custom_components/composite/config.py
+++ b/custom_components/composite/config.py
@@ -82,9 +82,7 @@ def _entity_picture(entity_picture: str) -> str:
     return str(local_dir / local_file)
 
 
-def _trackers(
-    trackers: list[dict[vol.Required | vol.Optional, Any]]
-) -> list[dict[vol.Required | vol.Optional, Any]]:
+def _trackers(trackers: list[dict[str, Any]]) -> list[dict[str, Any]]:
     """Validate tracker entries.
 
     Determine tracker IDs and ensure they are unique.

--- a/custom_components/composite/config_flow.py
+++ b/custom_components/composite/config_flow.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from abc import abstractmethod
-from functools import cached_property
+from functools import cached_property  # pylint: disable=hass-deprecated-import
 import logging
 from pathlib import Path
 import shutil

--- a/custom_components/composite/device_tracker.py
+++ b/custom_components/composite/device_tracker.py
@@ -37,7 +37,7 @@ from homeassistant.const import (
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
 )
-from homeassistant.core import Event, HomeAssistant, State
+from homeassistant.core import Event, EventStateChangedData, HomeAssistant, State
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -329,7 +329,7 @@ class CompositeDeviceTracker(TrackerEntity, RestoreEntity):
             self._attr_entity_picture = None
             self._use_entity_picture = False
 
-        async def state_listener(event: Event) -> None:
+        async def state_listener(event: Event[EventStateChangedData]) -> None:
             """Process input entity state update."""
             await self.async_request_call(
                 self._entity_updated(event.data["entity_id"], event.data["new_state"])

--- a/custom_components/composite/manifest.json
+++ b/custom_components/composite/manifest.json
@@ -4,9 +4,9 @@
   "codeowners": ["@pnbruckner"],
   "config_flow": true,
   "dependencies": ["file_upload"],
-  "documentation": "https://github.com/pnbruckner/ha-composite-tracker/blob/3.4.5/README.md",
+  "documentation": "https://github.com/pnbruckner/ha-composite-tracker/blob/3.5.0b0/README.md",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/pnbruckner/ha-composite-tracker/issues",
   "requirements": ["filetype==1.2.0"],
-  "version": "3.4.5"
+  "version": "3.5.0b0"
 }

--- a/custom_components/composite/sensor.py
+++ b/custom_components/composite/sensor.py
@@ -98,7 +98,6 @@ class CompositeSensor(SensorEntity):
             ]
 
         self._attr_native_value = value
-        self._attr_force_update = bool(value)
         self._attr_extra_state_attributes = {
             ATTR_ANGLE: angle,
             ATTR_DIRECTION: direction(angle),

--- a/hacs.json
+++ b/hacs.json
@@ -1,4 +1,4 @@
 {
   "name": "Composite Device Tracker",
-  "homeassistant": "2023.7"
+  "homeassistant": "2024.8.3"
 }


### PR DESCRIPTION
- Drop support for HA versions before 2024.8.3.
- Move file I/O to executor.
- Don't force sensor updates.